### PR TITLE
Add build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://github.com/thumbtack/thumbprint-ios/workflows/CI/badge.svg)](https://github.com/thumbtack/thumbprint-ios/actions?query=workflow%3ACI+branch%3Amain)
+[![Build Status](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml)
 
 ![Thumbprint iOS header](./.github/thumbprint-header.png)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://github.com/thumbtack/thumbprint-ios/workflows/CI/badge.svg)](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml)
+[![Build status](https://github.com/thumbtack/thumbprint-ios/workflows/CI/badge.svg)](https://github.com/thumbtack/thumbprint-ios/actions?query=workflow%3ACI+branch%3Amain)
 
 ![Thumbprint iOS header](./.github/thumbprint-header.png)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build status](https://github.com/thumbtack/thumbprint-ios/workflows/CI/badge.svg)](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml)
+
 ![Thumbprint iOS header](./.github/thumbprint-header.png)
 
 # Thumbprint


### PR DESCRIPTION
Adds this badge to the top of the README showing whether `main` is currently passing/failing CI.
![Screen Shot 2021-03-23 at 12 14 41 PM](https://user-images.githubusercontent.com/5143642/112204836-5e36af80-8bd1-11eb-8edb-b5f008ecca9b.png)
