### PR TITLE
Fix warnings caused by carousel layout

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/Button.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Button.swift
@@ -220,10 +220,14 @@ public final class Button: Control, UIContentSizeCategoryAdjusting {
 
         //  Center and add content width less than button width in case of tight layout clipping.
         let widthConstraint = contentView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor)
+        let heightConstraint = contentView.heightAnchor.constraint(equalTo: heightAnchor)
+        heightConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate([
             contentView.centerXAnchor.constraint(equalTo: centerXAnchor),
             contentView.centerYAnchor.constraint(equalTo: centerYAnchor),
             widthConstraint,
+            heightConstraint,
+            contentView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor)
         ])
 
         //  We allow some expansion of the label beyond the padding on tight layouts but limit it to 2/3 of the

--- a/Thumbprint/Targets/Thumbprint/Components/Button.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Button.swift
@@ -227,12 +227,12 @@ public final class Button: Control, UIContentSizeCategoryAdjusting {
             contentView.centerYAnchor.constraint(equalTo: centerYAnchor),
             widthConstraint,
             heightConstraint,
-            contentView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor)
+            contentView.heightAnchor.constraint(lessThanOrEqualTo: heightAnchor),
         ])
 
         //  We allow some expansion of the label beyond the padding on tight layouts but limit it to 2/3 of the
         //  declared padding as to avoid really messing the look of the button. Constant is set in `updateSize()`
-        maxContentWidthConstraint = widthConstraint
+        self.maxContentWidthConstraint = widthConstraint
 
         contentView.addArrangedSubview(titleLabel)
         titleLabel.adjustsFontSizeToFitWidth = adjustsFontForContentSizeCategory

--- a/Thumbprint/Targets/Thumbprint/Layouts/CarouselLayout.swift
+++ b/Thumbprint/Targets/Thumbprint/Layouts/CarouselLayout.swift
@@ -26,7 +26,11 @@ open class CarouselLayout: UICollectionViewFlowLayout {
 
     // MARK: - Making this a left aligned, 1 row layout
     public override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        super.layoutAttributesForElements(in: rect)?.map {
+        guard let superAttributes = super.layoutAttributesForElements(in: rect),
+              let attributes = NSArray(array: superAttributes, copyItems: true) as? [UICollectionViewLayoutAttributes]
+        else { return nil }
+
+        return attributes.map {
             if $0.representedElementKind == nil, let itemAttributes = layoutAttributesForItem(at: $0.indexPath) {
                 return itemAttributes
             } else {
@@ -36,12 +40,12 @@ open class CarouselLayout: UICollectionViewFlowLayout {
     }
 
     public override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        guard let currentItemAttributes = super.layoutAttributesForItem(at: indexPath) else {
+        guard let superAttributes = super.layoutAttributesForItem(at: indexPath),
+              let attributes = superAttributes.copy() as? UICollectionViewLayoutAttributes else {
             return nil
         }
 
-        // Force top-alignment
-        currentItemAttributes.frame.origin.y = sectionInset.top
-        return currentItemAttributes
+        attributes.frame.origin.y = sectionInset.top // Force top-alignment
+        return attributes
     }
 }


### PR DESCRIPTION
Currently at runtime, the following warning is printed to the console
when CarouselLayout is used: "UICollectionViewFlowLayout has cached
frame mismatch for index path ... This is likely occurring because the
flow layout subclass CarouselLayout is modifying attributes returned
by UICollectionViewFlowLayout without copying them."

Address this by copying the UICollectionViewLayoutAttributes
instances returned by the super implementation before modifying them.