### PR TITLE
Create manual GitHub Action to publish new release

### DIFF
--- a/.github/scripts/set_podspec_version.sh
+++ b/.github/scripts/set_podspec_version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# Search podspec for `.version = '1.2.3` and update with new version
+# number passed in as script argument.
+sed -i.bak -E "s/\.version *= *(["'"'"'])[0-9]\.[0-9]\.[0-9]["'"'"']/.version = \1$1\1/g" Thumbprint.podspec
+rm Thumbprint.podspec.bak
+
+# Install GitHub CLI.
+if ! command -v gh &> /dev/null; then
+    brew install gh
+fi
+
+# Create PR with the podspec change and merge into `main`.
+git checkout -b "kb/release-$1"
+git add Thumbprint.podspec
+git commit -m "Release ${{ github.events.inputs.version }}"
+gh pr create --fill
+gh pr review --approve
+gh pr merge --squash
+git checkout main
+git pull

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Publish Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number for new release (x.x.x)'
+        required: true
+jobs:
+  test:
+    name: Run tests
+    runs-on: macos-10.15
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v2
+
+      - name: 🍫 Update podspec
+        run: sh .github/scripts/set_podspec_version.sh "${{ github.events.inputs.version }}"
+
+      - name: 🏷 Create release tag
+        run: git tag "${{ github.events.inputs.version }}" && git push --tags
+
+      - name: 🪧 Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: "${{ github.events.inputs.version }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🚀 Publish pod
+        run: pod trunk push Thumbprint.podspec --allow-warnings
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
Automate the process of releasing new versions of the Thumbprint
pod by defining a GitHub Action that can be triggered manually,
taking as input the version number to assign to the new release.