### PR TITLE
Allow a custom ChipPill within Chip

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
@@ -69,8 +69,13 @@ public class Chip: Control {
     private var feedbackGenerator: UISelectionFeedbackGenerator?
 
     // MARK: - Public API
-    public init(adjustsFontForContentSizeCategory: Bool = true) {
-        self.pill = ChipPill(adjustsFontForContentSizeCategory: adjustsFontForContentSizeCategory)
+    public convenience init(adjustsFontForContentSizeCategory: Bool = true) {
+        let pill = ChipPill(adjustsFontForContentSizeCategory: adjustsFontForContentSizeCategory)
+        self.init(pill: pill)
+    }
+
+    public init(pill: ChipPill) {
+        self.pill = pill
         self.isHapticFeedbackEnabled = true
 
         super.init(frame: .null)
@@ -198,7 +203,7 @@ extension Chip: UIContentSizeCategoryAdjusting {
 private class ChipPill: Pill {
     // MARK: - Class configuration
 
-    override class var defaultHeight: CGFloat {
+    open override class var defaultHeight: CGFloat {
         return 32.0
     }
 
@@ -206,7 +211,7 @@ private class ChipPill: Pill {
         return 16.0
     }
 
-    override class var textStyle: Font.TextStyle {
+    open override class var textStyle: Font.TextStyle {
         return .title8
     }
 

--- a/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
@@ -200,7 +200,7 @@ extension Chip: UIContentSizeCategoryAdjusting {
 /**
  Basically a pill with facilities to add a border.
  */
-private class ChipPill: Pill {
+open class ChipPill: Pill {
     // MARK: - Class configuration
 
     open override class var defaultHeight: CGFloat {

--- a/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
@@ -249,7 +249,7 @@ open class ChipPill: Pill {
         }
     }
 
-    override func layoutSubviews() {
+    open override func layoutSubviews() {
         super.layoutSubviews()
 
         //  Configure the border as set up.

--- a/Thumbprint/Targets/Thumbprint/Components/Pill.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Pill.swift
@@ -6,7 +6,7 @@ import UIKit
  See documentation at https://thumbprint.design/components/pill/ios
 
  Pills often get used, as a UI element, for other purposes beyond simple informative labels so the API presented
- here is a bit more exptensive than what is needed for the component's ostensible intended use.
+ here is a bit more extensive than what is needed for the component's ostensible intended use.
  */
 open class Pill: UIView, UIContentSizeCategoryAdjusting {
     // MARK: - Class configuration


### PR DESCRIPTION
This pr adds the ability to drop in a custom `ChipPill`

Example Client Side Usage:

Say we have a one off subclass with some new parameters
```
// MARK: - Larger Pill
final private class ChipPillLarge: ChipPill {
    override class var defaultHeight: CGFloat {
        48.0
    }

    override class var textStyle: Font.TextStyle {
        return .title7
    }
}
```
We can now construct our `Chip` / Subclass with the new `ChipPill`

`let chip = ToggleChip(pill: ChipPillLarge())`