### PR TITLE
Add badge to README for pod version and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml)
 [![CocoaPod Latest Version](https://shields.io/cocoapods/v/Thumbprint?color=informational)](https://github.com/thumbtack/thumbprint-ios/releases)
+[![License](https://badgen.net/github/license/thumbtack/thumbprint-ios)](https://github.com/thumbtack/thumbprint-ios/blob/main/LICENSE)
 
 ![Thumbprint iOS header](./.github/thumbprint-header.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml)
 [![CocoaPod Latest Version](https://shields.io/cocoapods/v/Thumbprint?color=informational)](https://github.com/thumbtack/thumbprint-ios/releases)
-[![License](https://badgen.net/github/license/thumbtack/thumbprint-ios)](https://github.com/thumbtack/thumbprint-ios/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/thumbtack/thumbprint-ios?color=important)](https://github.com/thumbtack/thumbprint-ios/blob/main/LICENSE)
 
 ![Thumbprint iOS header](./.github/thumbprint-header.png)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/thumbtack/thumbprint-ios/actions/workflows/ci.yml)
+[![CocoaPod Latest Version](https://shields.io/cocoapods/v/Thumbprint?color=informational)](https://github.com/thumbtack/thumbprint-ios/releases)
 
 ![Thumbprint iOS header](./.github/thumbprint-header.png)
 


### PR DESCRIPTION
Adds a badge to the README showing the latest version of the cocoapod, as well as license under which Thumbprint is released:
<img width="316" alt="Screen Shot 2021-05-16 at 3 26 46 PM" src="https://user-images.githubusercontent.com/5143642/118414742-386ed980-b65b-11eb-9dab-3945565994ca.png">

