### PR TITLE
Allow Button's accessibility label to be set

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/Button.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Button.swift
@@ -141,6 +141,15 @@ public final class Button: Control, UIContentSizeCategoryAdjusting {
         }
     }
 
+    public override var accessibilityLabel: String? {
+        get {
+            super.accessibilityLabel ?? title
+        }
+        set {
+            super.accessibilityLabel = newValue
+        }
+    }
+
     public override var intrinsicContentSize: CGSize {
         var intrinsicWidth = size.contentPadding.width * 2.0 + titleLabel.intrinsicContentSize.width
         if icon != nil {
@@ -345,10 +354,6 @@ private extension Button {
             titleLabel.text = newValue
         }
         invalidateIntrinsicContentSize()
-
-        if accessibilityLabel == nil {
-            accessibilityLabel = newValue
-        }
     }
 
     private func updateTheme() {

--- a/Thumbprint/Targets/Thumbprint/Components/Button.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Button.swift
@@ -141,16 +141,6 @@ public final class Button: Control, UIContentSizeCategoryAdjusting {
         }
     }
 
-    public override var accessibilityLabel: String? {
-        get {
-            title
-        }
-        set {
-            _ = newValue
-            assertionFailure("Accessibility label of Thumbprint buttons is set to the button's title, and so cannot be overridden.")
-        }
-    }
-
     public override var intrinsicContentSize: CGSize {
         var intrinsicWidth = size.contentPadding.width * 2.0 + titleLabel.intrinsicContentSize.width
         if icon != nil {
@@ -355,6 +345,10 @@ private extension Button {
             titleLabel.text = newValue
         }
         invalidateIntrinsicContentSize()
+
+        if accessibilityLabel == nil {
+            accessibilityLabel = newValue
+        }
     }
 
     private func updateTheme() {

--- a/Thumbprint/Targets/ThumbprintTests/Unit/Components/ButtonUnitTest.swift
+++ b/Thumbprint/Targets/ThumbprintTests/Unit/Components/ButtonUnitTest.swift
@@ -1,9 +1,3 @@
-//
-//  ButtonUnitTest.swift
-//  ThumbprintTests
-//
-//  Created by yliao on 6/2/21.
-//
 @testable import Thumbprint
 import XCTest
 

--- a/Thumbprint/Targets/ThumbprintTests/Unit/Components/ButtonUnitTest.swift
+++ b/Thumbprint/Targets/ThumbprintTests/Unit/Components/ButtonUnitTest.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 class ButtonUnitTest: XCTestCase {
-
     func testAccessibilityLabel() {
         let button = Button()
         XCTAssertNil(button.title)
@@ -20,5 +19,4 @@ class ButtonUnitTest: XCTestCase {
         button.title = nil
         XCTAssertEqual(button.accessibilityLabel, "smash it to select an item")
     }
-
 }

--- a/Thumbprint/Targets/ThumbprintTests/Unit/Components/ButtonUnitTest.swift
+++ b/Thumbprint/Targets/ThumbprintTests/Unit/Components/ButtonUnitTest.swift
@@ -1,0 +1,30 @@
+//
+//  ButtonUnitTest.swift
+//  ThumbprintTests
+//
+//  Created by yliao on 6/2/21.
+//
+@testable import Thumbprint
+import XCTest
+
+class ButtonUnitTest: XCTestCase {
+
+    func testAccessibilityLabel() {
+        let button = Button()
+        XCTAssertNil(button.title)
+        XCTAssertNil(button.accessibilityLabel)
+
+        button.title = "tap it"
+        XCTAssertEqual(button.accessibilityLabel, "tap it")
+
+        button.title = "smash it"
+        XCTAssertEqual(button.accessibilityLabel, "smash it")
+
+        button.accessibilityLabel = "smash it to select an item"
+        XCTAssertEqual(button.accessibilityLabel, "smash it to select an item")
+
+        button.title = nil
+        XCTAssertEqual(button.accessibilityLabel, "smash it to select an item")
+    }
+
+}

--- a/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
+++ b/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		08C81F3825F5AA1B0082FD2D /* UnitTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C81F3725F5AA1B0082FD2D /* UnitTestCase.swift */; };
 		08DC57BD26003E2E00B95596 /* libPods-ThumbprintTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 08DC57BC26003E2E00B95596 /* libPods-ThumbprintTests.a */; };
 		7B7A49A6AABE9CD4F18A04F0 /* libPods-Thumbprint.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F0A99A127B8BB41E56278E96 /* libPods-Thumbprint.a */; };
+		B98FE98D2668312400B52979 /* ButtonUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98FE98C2668312400B52979 /* ButtonUnitTest.swift */; };
 		CD5A0287B7D3129E8BDD06E5 /* libPods-TestsHostApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82BB25065E7ACE32CDDE00D1 /* libPods-TestsHostApp.a */; };
 		FF2929B62642168D001A711A /* RadioStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2929B52642168D001A711A /* RadioStack.swift */; };
 		FF2929B82642306F001A711A /* RadioGroupTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2929B72642306F001A711A /* RadioGroupTest.swift */; };
@@ -278,6 +279,7 @@
 		7F9C8BBA2599C336FF37A86E /* Pods-ThumbprintTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThumbprintTests.debug.xcconfig"; path = "Target Support Files/Pods-ThumbprintTests/Pods-ThumbprintTests.debug.xcconfig"; sourceTree = "<group>"; };
 		82BB25065E7ACE32CDDE00D1 /* libPods-TestsHostApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestsHostApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D662BAB622080BBA7DEF81C /* Pods-Thumbprint.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Thumbprint.release.xcconfig"; path = "Target Support Files/Pods-Thumbprint/Pods-Thumbprint.release.xcconfig"; sourceTree = "<group>"; };
+		B98FE98C2668312400B52979 /* ButtonUnitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonUnitTest.swift; sourceTree = "<group>"; };
 		C54C542DED491DAB0804B642 /* Pods-TestsHostApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestsHostApp.debug.xcconfig"; path = "Target Support Files/Pods-TestsHostApp/Pods-TestsHostApp.debug.xcconfig"; sourceTree = "<group>"; };
 		D12EA88E3D1B084D408E2707 /* Pods-ThumbprintTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThumbprintTests.release.xcconfig"; path = "Target Support Files/Pods-ThumbprintTests/Pods-ThumbprintTests.release.xcconfig"; sourceTree = "<group>"; };
 		E960F8432D6A9D65F3873172 /* Pods-TestsHostApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestsHostApp.release.xcconfig"; path = "Target Support Files/Pods-TestsHostApp/Pods-TestsHostApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -639,6 +641,7 @@
 			children = (
 				08C81A7C25F5A66B0082FD2D /* AlertBannerUnitTest.swift */,
 				FF2929B72642306F001A711A /* RadioGroupTest.swift */,
+				B98FE98C2668312400B52979 /* ButtonUnitTest.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1043,6 +1046,7 @@
 				08C81CE325F5A6B60082FD2D /* ShadowCardTest.swift in Sources */,
 				08C81CDF25F5A6B60082FD2D /* FilterChipTest.swift in Sources */,
 				08C81CDC25F5A6B60082FD2D /* PartialSheetTest.swift in Sources */,
+				B98FE98D2668312400B52979 /* ButtonUnitTest.swift in Sources */,
 				08C81CDE25F5A6B60082FD2D /* TabBarTest.swift in Sources */,
 				08C81CE425F5A6B60082FD2D /* CalendarPickerTest.swift in Sources */,
 				08C81CE825F5A6B60082FD2D /* NavigationBarTest.swift in Sources */,


### PR DESCRIPTION
Currently `Button`'s `accessibilityLabel` uses `title` as its value and cannot be set. This PR makes it so `Button` will allow `accessibilityLabel` to be set and use `title` if it isn't set.