### PR TITLE
Fix automated release version bump PRs

### DIFF
--- a/.github/scripts/commit_release.sh
+++ b/.github/scripts/commit_release.sh
@@ -7,11 +7,11 @@ git checkout -b "release/$1"
 # Update version in podspec.
 # (Search podspec for `.version = '1.2.3` and update with new version
 # number passed in as script argument).
-sed -i.bak -E "s/\.version *= *(["'"'"'])[0-9]\.[0-9]\.[0-9]["'"'"']/.version = \1$1\1/g" Thumbprint.podspec
+sed -i.bak -E "s/\.version *= *(["'"'"'])[0-9](\.[0-9])?(\.[0-9])?["'"'"']/.version = \1$1\1/g" Thumbprint.podspec
 rm Thumbprint.podspec.bak
 
 # Commit changes and push.
 git add --all
 git commit -m "Release $1"
-git push origin $(git branch --show-current)
-gh pr create --title "Release $1" --body ""
+git push https://$GITHUB_TOKEN@github.com/thumbtack/thumbprint-ios.git head:$(git branch --show-current)
+gh pr create --title "Release $1" --body "" --head $(git branch --show-current)

--- a/.github/scripts/tag_release.sh
+++ b/.github/scripts/tag_release.sh
@@ -3,4 +3,4 @@
 set -e -o pipefail
 
 git tag "$1"
-git push --tags
+git push --tags https://$GITHUB_TOKEN@github.com/thumbtack/thumbprint-ios.git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,26 +12,30 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v2
-
-      - name: ⬇️ Install GitHub CLI
-        run: if ![ command -v gh ]; then brew install gh; fi
+        with:
+          token: ${{ secrets.RELEASE_PERSONAL_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - name: 🍫 Bump version in podspec
         run: sh .github/scripts/commit_release.sh "${{ github.event.inputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # When the default secrets.GITHUB_TOKEN is used to push the version bump branch,
+          # GitHub will not trigger the `push` event that triggers CI to run on that branch.
+          # To ensure that CI is still triggered, use a separate personal access token with
+          # [public_repo] scope.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PERSONAL_ACCESS_TOKEN }}
 
       - name: 🏷 Create release tag
         run: sh .github/scripts/tag_release.sh "${{ github.event.inputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PERSONAL_ACCESS_TOKEN }}
 
       - name: 🪧 Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: "${{ github.event.inputs.version }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PERSONAL_ACCESS_TOKEN }}
 
       - name: 🚀 Publish pod
         run: pod trunk push Thumbprint.podspec --allow-warnings


### PR DESCRIPTION
When releasing new versions, the release action automatically creates
a PR bumping the pod version. However by default, push actions
triggered by another action do not trigger the usual push event. Using
a separate personal access token disables this behavior.