### PR TITLE
Improve release version regex pattern

### DIFF
--- a/.github/scripts/commit_release.sh
+++ b/.github/scripts/commit_release.sh
@@ -7,8 +7,11 @@ git checkout -b "release/$1"
 # Update version in podspec.
 # (Search podspec for `.version = '1.2.3` and update with new version
 # number passed in as script argument).
-sed -i.bak -E "s/\.version *= *(["'"'"'])[0-9](\.[0-9])?(\.[0-9])?["'"'"']/.version = \1$1\1/g" Thumbprint.podspec
-rm Thumbprint.podspec.bak
+#
+# Regex pattern adapted from
+# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+# for compatibility with sed.
+sed -i "" -E "s/\.version *= *(["'"'"'])(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?["'"'"']/.version = \1$1\1/g" Thumbprint.podspec
 
 # Commit changes and push.
 git add --all


### PR DESCRIPTION
As pointed out in https://github.com/thumbtack/thumbprint-ios/pull/34,
the regular expression used by the release script did not handle
some valid cases (e.g., "10.11.12", or prerelease versions like
"10.11.12-beta").

Update the pattern to use a version of that recommended by
https://semver.org.