### PR TITLE
Generic, injectable event reporting for Thumbprint.

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Reporting/AppEvent.swift
+++ b/Thumbprint/Targets/Thumbprint/Reporting/AppEvent.swift
@@ -1,0 +1,305 @@
+import Foundation
+
+/**
+ Encapsulates information about an event that happens during the app lifetime, usually for purposes of analytics event tracking.
+ */
+public struct AppEvent {
+    /**
+     Basic initializer.
+     - Parameter identifier: The event identifier.
+     - Parameter environment: The environment where the event happened. Defaults to no environment information.
+     - Parameter parameters: The event's parameters. Defaults to no parameters.
+     */
+    public init(_ identifier: Identifier, environment: [EnvironmentElement] = [], parameters: Parameters = [:]) {
+        self.identifier = identifier
+        self.environment = environment
+        self.parameters = parameters
+    }
+
+    // MARK: - Types
+
+    /**
+     Identifier for an app event. Should be short and to the point, and err on the side of semantics over specifics —for example
+     a event triggered by the user pressing a close button should have an identifier of “close” or “dismiss” rather than “button press”,
+     with the fact that it happened due to a button pressed reflected in the event's `environment`.
+
+     Identifiers should be declared as static instances of the type wherever appropriate.
+
+     In debug builds the framework will verify whether identifiers are unique by keeping track of all instantiated identifier strings and
+     asserting that they haven't been instantiated before.
+     */
+    public struct Identifier: RawRepresentable, Hashable {
+        public init(rawValue: String) {
+            #if DEBUG
+                assert(!Self.registeredIdentifiers.contains(rawValue))
+                Self.registeredIdentifiers.insert(rawValue)
+            #endif
+
+            self.rawValue = rawValue
+        }
+
+        public var rawValue: String
+
+        #if DEBUG
+            public private(set) static var registeredIdentifiers = Set<RawValue>()
+        #endif
+    }
+
+    /**
+     Describes an environment element of the event. These should describe a part of where the event happened, like
+     within a particular app screen or what control triggered it.
+
+     Thumbprint doesn't currently enforce uniqueness of environment elements in any way. If an adoption may require so it will
+     need to be enforced externally.
+     */
+    public struct EnvironmentElement: RawRepresentable, Hashable {
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        public var rawValue: String
+    }
+
+    /**
+     A key for an event's parameters dictionary. These should be as limited a set as possible so the same parameters always are
+     stored in the same keys.
+
+     Identifiers should be declared as static instances of the type wherever appropriate.
+
+     In debug builds the framework will verify whether keys are unique by keeping track of all instantiated parameter key strings and
+     asserting that they haven't been instantiated before.
+     */
+    public struct ParameterKey: RawRepresentable, Hashable {
+        public init(rawValue: String) {
+            #if DEBUG
+                assert(!Self.registeredParameterKeys.contains(rawValue))
+                Self.registeredParameterKeys.insert(rawValue)
+            #endif
+
+            self.rawValue = rawValue
+        }
+
+        public var rawValue: String
+
+        #if DEBUG
+            public private(set) static var registeredParameterKeys = Set<RawValue>()
+        #endif
+    }
+
+    /**
+     Allowed value types for app event reporting parameters. They track JSON data types, with the addition of `Date` and `Bool` since
+     they tend to get different custom treatments depending on internal API contracts.
+     */
+    public enum ParameterValue: Hashable {
+        case boolean(Bool)
+        case integer(Int)
+        case floatingPoint(Double)
+        case string(String)
+        case date(Date)
+        case array([ParameterValue])
+        case dictionary([String: ParameterValue])
+        case null
+    }
+
+    /**
+     The type used for event parameter storage.
+     */
+    public typealias Parameters = [ParameterKey: ParameterValue]
+
+    // MARK: - Properties
+
+    /**
+     The event identifier.
+     */
+    var identifier: Identifier
+
+    /**
+     This array should describe where and/or in what application state the event happened. For example when reporting that the user
+     pressed a close button in a subscription offer modal you would get something like `[“subscription modal”, ”dimiss button”]`.
+     The specifics for how this property is to be built up are usually to be agreed between engineering and analytics.
+     */
+    var environment: [EnvironmentElement]
+
+    /**
+     Additional parameters for the event. What these are depends on the event and on the reporting requirements.
+     */
+    var parameters: Parameters
+}
+
+public extension AppEvent.Parameters {
+    /**
+     Alternate dictionary subscript to make it simpler to add parameter values to an event's parameter dictionary.
+     - Warning: The getter will assert if there's a parameter value for the given key but it is not convertible to the expected type.
+     As such it is not generally recommended to use this subscript getter without further validation.
+     - Note: TODO (Oscar) investigate using a throwing property for the getter once Swift 6 is standard.
+     */
+    subscript<T>(_ key: Key) -> T? where T: ConvertibleToAppEventParameterValue {
+        get {
+            guard let value = self[key] else {
+                // No actual value in the dictionary, ok to just return nil.
+                return nil
+            }
+
+            guard let result = T(appEventParameterValue: value) else {
+                // TODO: (Oscar) assert.
+                return nil
+            }
+
+            return result
+        }
+
+        set {
+            self[key] = newValue?.appEventParameterValue
+        }
+    }
+}
+
+/**
+ A protocol for types to implement so they can easily be converted into app event parameter values and back.
+ */
+public protocol ConvertibleToAppEventParameterValue {
+    /**
+     Failable initializer to quickly convert from a `AppEvent.ParameterValue` enum to the convertible type.
+
+     Implementations should only convert to directly related types, return nil otherwise. For example don't convert from
+     `Integer` to a custom floating point type.
+     - Parameter appEventParameterValue: The parameter value we'd like to try converting.
+     - Note: TODO (Oscar) investigate using throwing initializers once Swift 6 is standard.
+     */
+    init?(appEventParameterValue: AppEvent.ParameterValue)
+
+    /**
+     Returns the calling value wrapped in a `AppEvent.ParameterValue` enum.
+     */
+    var appEventParameterValue: AppEvent.ParameterValue { get }
+}
+
+// MARK: - Common implementations of `ConvertibleToAppEventParameterValue`
+
+extension Bool: ConvertibleToAppEventParameterValue {
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .boolean(boolean) = appEventParameterValue {
+            self = boolean
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .boolean(self)
+    }
+}
+
+extension Int: ConvertibleToAppEventParameterValue {
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .integer(integer) = appEventParameterValue {
+            self = integer
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .integer(self)
+    }
+}
+
+extension Double: ConvertibleToAppEventParameterValue {
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .floatingPoint(floatingPoint) = appEventParameterValue {
+            self = floatingPoint
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .floatingPoint(self)
+    }
+}
+
+extension Float: ConvertibleToAppEventParameterValue {
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .floatingPoint(floatingPoint) = appEventParameterValue {
+            self = Float(floatingPoint)
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .floatingPoint(Double(self))
+    }
+}
+
+extension String: ConvertibleToAppEventParameterValue {
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .string(string) = appEventParameterValue {
+            self = string
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .string(self)
+    }
+}
+
+extension Date: ConvertibleToAppEventParameterValue {
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .date(date) = appEventParameterValue {
+            self = date
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .date(self)
+    }
+}
+
+extension Array: ConvertibleToAppEventParameterValue where Element: ConvertibleToAppEventParameterValue {
+    /**
+     Note that the array initializer will silently drop elements if they are not of the expected type even if `appEventParameterValue` is
+     indeed storing an array.
+     */
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .array(array) = appEventParameterValue {
+            self = array.compactMap { $0 as? Element }
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .array(map { element in
+            element.appEventParameterValue
+        })
+    }
+}
+
+extension Dictionary: ConvertibleToAppEventParameterValue where Key == String, Value: ConvertibleToAppEventParameterValue {
+    /**
+     Note that the dictionary initializer will silently drop values if they are not of the expected type even if `appEventParameterValue` is
+     indeed storing a dictionary.
+     */
+    public init?(appEventParameterValue: AppEvent.ParameterValue) {
+        if case let .dictionary(dictionary) = appEventParameterValue {
+            self = .init(uniqueKeysWithValues: dictionary.compactMap({ key, value in
+                (value as? Value).map { value in
+                    (key, value)
+                }
+            }))
+        } else {
+            return nil
+        }
+    }
+
+    public var appEventParameterValue: AppEvent.ParameterValue {
+        .dictionary(.init(uniqueKeysWithValues: map({ key, value in
+            (key, value.appEventParameterValue)
+        })))
+    }
+}

--- a/Thumbprint/Targets/Thumbprint/Reporting/AppEvent.swift
+++ b/Thumbprint/Targets/Thumbprint/Reporting/AppEvent.swift
@@ -7,53 +7,22 @@ public struct AppEvent {
     /**
      Basic initializer.
      - Parameter identifier: The event identifier.
-     - Parameter environment: The environment where the event happened. Defaults to no environment information.
      - Parameter parameters: The event's parameters. Defaults to no parameters.
      */
-    public init(_ identifier: Identifier, environment: [EnvironmentElement] = [], parameters: Parameters = [:]) {
+    public init(_ identifier: Identifier, parameters: Parameters = [:]) {
         self.identifier = identifier
-        self.environment = environment
         self.parameters = parameters
     }
 
     // MARK: - Types
 
     /**
-     Identifier for an app event. Should be short and to the point, and err on the side of semantics over specifics —for example
-     a event triggered by the user pressing a close button should have an identifier of “close” or “dismiss” rather than “button press”,
-     with the fact that it happened due to a button pressed reflected in the event's `environment`.
+     Identifier for an app event.
 
      Identifiers should be declared as static instances of the type wherever appropriate.
-
-     In debug builds the framework will verify whether identifiers are unique by keeping track of all instantiated identifier strings and
-     asserting that they haven't been instantiated before.
      */
     public struct Identifier: RawRepresentable, Hashable {
         public init(rawValue: String) {
-            #if DEBUG
-                assert(!Self.registeredIdentifiers.contains(rawValue))
-                Self.registeredIdentifiers.insert(rawValue)
-            #endif
-
-            self.rawValue = rawValue
-        }
-
-        public var rawValue: String
-
-        #if DEBUG
-            public private(set) static var registeredIdentifiers = Set<RawValue>()
-        #endif
-    }
-
-    /**
-     Describes an environment element of the event. These should describe a part of where the event happened, like
-     within a particular app screen or what control triggered it.
-
-     Thumbprint doesn't currently enforce uniqueness of environment elements in any way. If an adoption may require so it will
-     need to be enforced externally.
-     */
-    public struct EnvironmentElement: RawRepresentable, Hashable {
-        public init(rawValue: String) {
             self.rawValue = rawValue
         }
 
@@ -61,29 +30,17 @@ public struct AppEvent {
     }
 
     /**
-     A key for an event's parameters dictionary. These should be as limited a set as possible so the same parameters always are
-     stored in the same keys.
+     A key for an event's parameters dictionary. These should be as limited a set as possible so the same parameters
+     always are stored in the same keys.
 
      Identifiers should be declared as static instances of the type wherever appropriate.
-
-     In debug builds the framework will verify whether keys are unique by keeping track of all instantiated parameter key strings and
-     asserting that they haven't been instantiated before.
      */
     public struct ParameterKey: RawRepresentable, Hashable {
         public init(rawValue: String) {
-            #if DEBUG
-                assert(!Self.registeredParameterKeys.contains(rawValue))
-                Self.registeredParameterKeys.insert(rawValue)
-            #endif
-
             self.rawValue = rawValue
         }
 
         public var rawValue: String
-
-        #if DEBUG
-            public private(set) static var registeredParameterKeys = Set<RawValue>()
-        #endif
     }
 
     /**
@@ -112,13 +69,6 @@ public struct AppEvent {
      The event identifier.
      */
     var identifier: Identifier
-
-    /**
-     This array should describe where and/or in what application state the event happened. For example when reporting that the user
-     pressed a close button in a subscription offer modal you would get something like `[“subscription modal”, ”dimiss button”]`.
-     The specifics for how this property is to be built up are usually to be agreed between engineering and analytics.
-     */
-    var environment: [EnvironmentElement]
 
     /**
      Additional parameters for the event. What these are depends on the event and on the reporting requirements.

--- a/Thumbprint/Targets/Thumbprint/Reporting/AppEventReporter.swift
+++ b/Thumbprint/Targets/Thumbprint/Reporting/AppEventReporter.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/**
+ Wrapper for app event reporting objects.
+
+ Thumbprint doesn't establish any dependency on any app event reporting API, but since integrating app event
+ reporting into its components can make the process far more consistent and reliable we allow for easy integration
+ with existing APIs.
+
+ Implementers must be objects as the app event reporter registry stores them by object identity.
+
+ The steps to follow for integration are the following:
+ - Create a class that wraps a given app event reporting API by implementing this protocol.
+ - Add an instance of it to the set of app event reporters by using `AppEvent.add(<instance>)`
+ - There is no step three.
+ */
+public protocol AppEventReporter: AnyObject {
+    /**
+     Reports an event with the given parameters and environment.
+     - Important: Implementations should have no side effects, and should know to disable themselves in the right
+     runtime environment if warranted (i.e. debug, testing etc.).
+     - Parameter event: The app event.
+     */
+    func report(_ event: AppEvent)
+}
+
+/**
+ Management of global event reporting.
+ - Note: TODO (Oscar) tackle multithreading considerations.
+ */
+public extension AppEvent {
+    /**
+     Reports the given event using the global event reporter.
+     - Parameter event: The event we want reported.
+     */
+    static func report(_ event: AppEvent) {
+        GroupedAppEventReporter.singleton.report(event)
+    }
+
+    /**
+     Reports the given event. Convenience method to avoid having to build an AppEvent on the fly.
+     */
+    static func report(_ identifier: AppEvent.Identifier, environment: [AppEvent.EnvironmentElement], parameters: [AppEvent.ParameterKey: AppEvent.ParameterValue]) {
+        report(.init(identifier, environment: environment, parameters: parameters))
+    }
+
+    /**
+     Pushes an event reporter on top of the stack. After this call further event reporting will also be reported
+     on `eventReported`. If the same event reporter is accidentally registered more than once subsequent attempts
+     will just do nothing.
+     - Parameter eventReporter: An event reporter that we want to add to the set of event reporters that get
+     sent events when globally reported.
+
+         There's no guarantee `eventReporter` will be called before or after any other registered event
+     reporters,
+     */
+    static func add(_ eventReporter: AppEventReporter) {
+        GroupedAppEventReporter.singleton.add(eventReporter)
+    }
+
+    /**
+     Removes the given event reporter from the global set. If the given event reporter has not been previously
+     registered nothing happens.
+     - Parameter eventReporter: An event reporter that we don't want receiving global app reported events any longer.
+
+     */
+    static func remove(_ eventReporter: AppEventReporter) {
+        GroupedAppEventReporter.singleton.remove(eventReporter)
+    }
+}
+
+/**
+ A private implementation of AppEventReporter for use to implement app global event reporting by keeping track of
+ registered event reporters and broadcasting event reports to them.
+
+ A singleton instance of it is used for most standard event reporting.
+ */
+private final class GroupedAppEventReporter {
+    init() {
+        #if DEBUG
+            add(DebugEventReporter())
+        #endif
+    }
+
+    static let singleton = GroupedAppEventReporter()
+
+    private var registeredEventReporters: [ObjectIdentifier: AppEventReporter] = [:]
+
+    func add(_ eventReporter: AppEventReporter) {
+        registeredEventReporters[.init(eventReporter)] = eventReporter
+    }
+
+    func remove(_ eventReporter: AppEventReporter) {
+        registeredEventReporters.removeValue(forKey: .init(eventReporter))
+    }
+}
+
+extension GroupedAppEventReporter: AppEventReporter {
+    func report(_ event: AppEvent) {
+        for eventReporter in registeredEventReporters.values {
+            eventReporter.report(event)
+        }
+    }
+}
+
+/**
+ Standard debug event reporter. Always registered in Debug builds, ensuring that event reporting is logged
+ where the developer can see it.
+ */
+private final class DebugEventReporter: AppEventReporter {
+    func report(_ event: AppEvent) {
+        print("*** Reported Event with identifier “\(event.identifier)”")
+        print("- Environment: \(event.environment)")
+        print("- Parameters: \(event.parameters)")
+    }
+}

--- a/Thumbprint/Targets/Thumbprint/Reporting/AppEventReporter.swift
+++ b/Thumbprint/Targets/Thumbprint/Reporting/AppEventReporter.swift
@@ -16,7 +16,7 @@ import Foundation
  */
 public protocol AppEventReporter: AnyObject {
     /**
-     Reports an event with the given parameters and environment.
+     Reports an event.
      - Important: Implementations should have no side effects, and should know to disable themselves in the right
      runtime environment if warranted (i.e. debug, testing etc.).
      - Parameter event: The app event.
@@ -39,9 +39,11 @@ public extension AppEvent {
 
     /**
      Reports the given event. Convenience method to avoid having to build an AppEvent on the fly.
+     - Parameter identifier: The event's identifier.
+     - Parameter parameters: The event's parameters.
      */
-    static func report(_ identifier: AppEvent.Identifier, environment: [AppEvent.EnvironmentElement], parameters: [AppEvent.ParameterKey: AppEvent.ParameterValue]) {
-        report(.init(identifier, environment: environment, parameters: parameters))
+    static func report(_ identifier: AppEvent.Identifier, parameters: [AppEvent.ParameterKey: AppEvent.ParameterValue]) {
+        report(.init(identifier, parameters: parameters))
     }
 
     /**
@@ -110,7 +112,6 @@ extension GroupedAppEventReporter: AppEventReporter {
 private final class DebugEventReporter: AppEventReporter {
     func report(_ event: AppEvent) {
         print("*** Reported Event with identifier “\(event.identifier)”")
-        print("- Environment: \(event.environment)")
         print("- Parameters: \(event.parameters)")
     }
 }

--- a/Thumbprint/Targets/Thumbprint/Reporting/TestEventReporter.swift
+++ b/Thumbprint/Targets/Thumbprint/Reporting/TestEventReporter.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/**
+ App event reporting should be covered by automated testing. Use this class to keep a record of app event reporting
+ during a test and verify that the expected app events have been reported at various stages.
+
+ Usage should be per test. Create an instance before the test runs (i.e. during `XCTestCase.setUp()`), add it to the set of app event
+ reporters using `AppEvent.register(_:)` and store it for the test duration so its contents can be verified. At the
+ end of the test (i.e. during `XCTestCase.tearDown()`) use `AppEvent.unregister(_:)` to remove the object and
+ then dispose of it.
+ - Note: TODO (Oscar) tackle multithreading considerations.
+ */
+public final class TestEventReporter {
+    // Stores events reported during the object's lifetime. Public access for test verification purposes.
+    public private(set) var events: [AppEvent] = []
+}
+
+extension TestEventReporter: AppEventReporter {
+    public func report(_ event: AppEvent) {
+        events.append(event)
+    }
+}

--- a/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
+++ b/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
@@ -113,6 +113,9 @@
 		FF858A1F269C1FD0002E22D8 /* RadioStackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF858A1E269C1FD0002E22D8 /* RadioStackTest.swift */; };
 		FFD57F232681189B004F2BBB /* LabeledControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD57F222681189B004F2BBB /* LabeledControl.swift */; };
 		FFE53483269D838F00FDD9A5 /* LabeledControlTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE53482269D838F00FDD9A5 /* LabeledControlTest.swift */; };
+		FFE536EE26A7AA6D00FDD9A5 /* AppEventReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE536ED26A7AA6D00FDD9A5 /* AppEventReporter.swift */; };
+		FFEB0CA026AE2C9500115A70 /* AppEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB0C9F26AE2C9500115A70 /* AppEvent.swift */; };
+		FFEB0CA326AE6ADB00115A70 /* TestEventReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB0CA226AE6ADB00115A70 /* TestEventReporter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -301,6 +304,9 @@
 		FF858A1E269C1FD0002E22D8 /* RadioStackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioStackTest.swift; sourceTree = "<group>"; };
 		FFD57F222681189B004F2BBB /* LabeledControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabeledControl.swift; sourceTree = "<group>"; };
 		FFE53482269D838F00FDD9A5 /* LabeledControlTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledControlTest.swift; sourceTree = "<group>"; };
+		FFE536ED26A7AA6D00FDD9A5 /* AppEventReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEventReporter.swift; sourceTree = "<group>"; };
+		FFEB0C9F26AE2C9500115A70 /* AppEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEvent.swift; sourceTree = "<group>"; };
+		FFEB0CA226AE6ADB00115A70 /* TestEventReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEventReporter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -388,6 +394,7 @@
 				08C819C325F574460082FD2D /* Presentations */,
 				08C819A925F574460082FD2D /* Components */,
 				08C81A7925F594560082FD2D /* Layouts */,
+				FFEB0CA126AE6AA000115A70 /* Reporting */,
 				08C819A425F574460082FD2D /* Tokens */,
 				08C819D725F574470082FD2D /* Utilities */,
 				080E7D4A25F490DC002DBE7B /* Supporting Files */,
@@ -745,6 +752,16 @@
 			path = ../Pods;
 			sourceTree = "<group>";
 		};
+		FFEB0CA126AE6AA000115A70 /* Reporting */ = {
+			isa = PBXGroup;
+			children = (
+				FFE536ED26A7AA6D00FDD9A5 /* AppEventReporter.swift */,
+				FFEB0C9F26AE2C9500115A70 /* AppEvent.swift */,
+				FFEB0CA226AE6ADB00115A70 /* TestEventReporter.swift */,
+			);
+			path = Reporting;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1032,11 +1049,14 @@
 				080E6F7025FFD38D006D8056 /* ToggleChip.swift in Sources */,
 				FF1A3E3D2697F44A00561D28 /* LabeledCheckbox.swift in Sources */,
 				080E6F5625FFD38D006D8056 /* UIViewController+Presentations.swift in Sources */,
+				FFEB0CA026AE2C9500115A70 /* AppEvent.swift in Sources */,
+				FFEB0CA326AE6ADB00115A70 /* TestEventReporter.swift in Sources */,
 				080E6F5B25FFD38D006D8056 /* UIView+Layout.swift in Sources */,
 				080E6F6B25FFD38D006D8056 /* RadioTableViewCell.swift in Sources */,
 				08649463260156F300EB82E8 /* Bundle+Extensions.swift in Sources */,
 				080E6F4C25FFD38D006D8056 /* CalendarPicker.swift in Sources */,
 				FFD57F232681189B004F2BBB /* LabeledControl.swift in Sources */,
+				FFE536EE26A7AA6D00FDD9A5 /* AppEventReporter.swift in Sources */,
 				080E6F7225FFD38D006D8056 /* Control.swift in Sources */,
 				080E6F6E25FFD38D006D8056 /* UIView+StackView.swift in Sources */,
 				080E6F5425FFD38D006D8056 /* Label.swift in Sources */,


### PR DESCRIPTION
WHY:

App event reporting is often done in a haphazard fashion resulting in bugs and inconsistencies when producing the reported events that then cause the data that analysts use to be far less trustworthy than we would all like.

Integrating event reporting in Thumbprint components would go a long way towards ensuring reporting consistency, which means the basic implementation of the components should know to do so.

However, we definitely do not want to add any dependencies in Thumbprint to external app event reporting frameworks/APIs. Therefore a generic solution that is easy to integrate with existing systems is the most sensible approach.

WHAT:

- Declared a basic app event type.
- Declared a protocol for app event reporting.
- Implemented basic global management of a registry of app event reporting objects.
- Included basic debug and testing app event reporting.
- Documented the whole thing.

TESTING:

This is more of a request for comments PR and is not in use by anyone so far. Once an API is agreed to and integration with Thumbtack is considered we can look at adding automated testing.