### PR TITLE
Add present/dismiss notifications for partial sheets

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -170,7 +170,7 @@ open class PartialSheetPresentationController: UIPresentationController {
             grabberView.alpha = 1
         }
 
-        NotificationCenter.default.post(Notification.Name.PartialSheetDidPresentNotification)
+        NotificationCenter.default.post(name: Notification.Name.PartialSheetDidPresentNotification, object: nil)
     }
 
     @objc
@@ -236,7 +236,7 @@ open class PartialSheetPresentationController: UIPresentationController {
         if completed {
             partialSheetDelegate?.partialSheetPresentationControllerDidDismissSheet?(self)
 
-            NotificationCenter.default.post(Notification.Name.PartialSheetDidDismissNotification)
+            NotificationCenter.default.post(name: Notification.Name.PartialSheetDidDismissNotification, object: nil)
         }
     }
 

--- a/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -17,8 +17,8 @@ public protocol PartialSheetPresentationControllerDelegate: UIAdaptivePresentati
 }
 
 open class PartialSheetPresentationController: UIPresentationController {
-    static let partialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
-    static let partialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
+    public static let partialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
+    public static let partialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
     
     private class SizeTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
         var isAnimated: Bool { false }

--- a/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+extension Notification.Name {
+    static let PartialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
+    static let PartialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
+}
+
 // TODO: (team) Much of what's included in this delegate has been added to UIAdaptivePresentationControllerDelegate
 // in iOS 13.  Once we're on a minimum target of iOS 13, we can get rid of PartialSheetPresentationControllerDelegate and
 // just use UIAdaptivePresentationControllerDelegate directly (for which UIPresentationController already has a delegate
@@ -164,6 +169,8 @@ open class PartialSheetPresentationController: UIPresentationController {
             dimmedView.alpha = 0.5
             grabberView.alpha = 1
         }
+
+        NotificationCenter.default.post(Notification.Name.PartialSheetDidPresentNotification)
     }
 
     @objc
@@ -228,6 +235,8 @@ open class PartialSheetPresentationController: UIPresentationController {
 
         if completed {
             partialSheetDelegate?.partialSheetPresentationControllerDidDismissSheet?(self)
+
+            NotificationCenter.default.post(Notification.Name.PartialSheetDidDismissNotification)
         }
     }
 

--- a/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -19,7 +19,7 @@ public protocol PartialSheetPresentationControllerDelegate: UIAdaptivePresentati
 open class PartialSheetPresentationController: UIPresentationController {
     public static let partialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
     public static let partialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
-    
+
     private class SizeTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
         var isAnimated: Bool { false }
         var presentationStyle: UIModalPresentationStyle { .none }

--- a/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -17,8 +17,8 @@ public protocol PartialSheetPresentationControllerDelegate: UIAdaptivePresentati
 }
 
 open class PartialSheetPresentationController: UIPresentationController {
-    static let PartialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
-    static let PartialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
+    static let partialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
+    static let partialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
     
     private class SizeTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
         var isAnimated: Bool { false }
@@ -168,7 +168,7 @@ open class PartialSheetPresentationController: UIPresentationController {
             grabberView.alpha = 1
         }
 
-        NotificationCenter.default.post(name: Notification.Name.PartialSheetDidPresentNotification, object: nil)
+        NotificationCenter.default.post(name: PartialSheetPresentationController.partialSheetDidPresentNotification, object: nil)
     }
 
     @objc
@@ -234,7 +234,7 @@ open class PartialSheetPresentationController: UIPresentationController {
         if completed {
             partialSheetDelegate?.partialSheetPresentationControllerDidDismissSheet?(self)
 
-            NotificationCenter.default.post(name: Notification.Name.PartialSheetDidDismissNotification, object: nil)
+            NotificationCenter.default.post(name: PartialSheetPresentationController.partialSheetDidDismissNotification, object: nil)
         }
     }
 

--- a/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Thumbprint/Targets/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -1,10 +1,5 @@
 import UIKit
 
-extension Notification.Name {
-    static let PartialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
-    static let PartialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
-}
-
 // TODO: (team) Much of what's included in this delegate has been added to UIAdaptivePresentationControllerDelegate
 // in iOS 13.  Once we're on a minimum target of iOS 13, we can get rid of PartialSheetPresentationControllerDelegate and
 // just use UIAdaptivePresentationControllerDelegate directly (for which UIPresentationController already has a delegate
@@ -22,6 +17,9 @@ public protocol PartialSheetPresentationControllerDelegate: UIAdaptivePresentati
 }
 
 open class PartialSheetPresentationController: UIPresentationController {
+    static let PartialSheetDidPresentNotification = Notification.Name("PartialSheetDidPresentNotification")
+    static let PartialSheetDidDismissNotification = Notification.Name("PartialSheetDidDismissNotification")
+    
     private class SizeTransitionCoordinator: NSObject, UIViewControllerTransitionCoordinator {
         var isAnimated: Bool { false }
         var presentationStyle: UIModalPresentationStyle { .none }


### PR DESCRIPTION
- add present/dismiss notifications for partial sheets

These notifications are intended to be used in cases where the overall application hierarchy needs to respond to presentation or dismissal events from partial sheets.