### PR TITLE
Support custom Avatar sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           path: Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
 
       - name: 🗂 Install Pods
         run: bundle exec pod install || bundle exec pod install --repo-update

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
   - RxSwift (6.2.0)
   - SnapKit (5.0.1)
   - SnapshotTesting (1.8.2)
-  - SwiftFormat/CLI (0.47.13)
+  - SwiftFormat/CLI (0.48.11)
   - SwiftLint (0.43.1)
   - ThumbprintTokens (12.1.1)
   - TTCalendarPicker (0.1.7):
@@ -48,7 +48,7 @@ SPEC CHECKSUMS:
   RxSwift: d356ab7bee873611322f134c5f9ef379fa183d8f
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   SnapshotTesting: 38947050d13960d57a4a9c166fcf51bca7d56970
-  SwiftFormat: 73573b89257437c550b03d934889725fbf8f75e5
+  SwiftFormat: 938e5865a118c49d63c7a290ddad86335f9e585f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
   ThumbprintTokens: cfb6b1a3bff5079010ea9b875f558d0016579209
   TTCalendarPicker: 41a4cecbc0be87bcc2aff2740c6cb835a1c26a90

--- a/Thumbprint/Targets/Playground/Classes/Inspectable/InspectableViews/EntityAvatar+InspectableView.swift
+++ b/Thumbprint/Targets/Playground/Classes/Inspectable/InspectableViews/EntityAvatar+InspectableView.swift
@@ -24,13 +24,10 @@ extension EntityAvatar: InspectableView {
         initialsProperty.title = "Initials"
         initialsProperty.property = \EntityAvatar.initials
 
-        let sizes: [(Avatar.Size, String)] = Avatar.Size.allSizes.map {
-            ($0, $0.name)
-        }
         let sizeProperty = DropdownInspectableProperty(
             inspectedView: self,
             property: \EntityAvatar.size,
-            values: sizes
+            values: Self.allSizes
         )
 
         return [
@@ -46,4 +43,12 @@ extension EntityAvatar: InspectableView {
         avatar.initials = "A"
         return avatar
     }
+
+    private static let allSizes = [
+        (Avatar.Size.xSmall, "xSmall"),
+        (Avatar.Size.small, "small"),
+        (Avatar.Size.medium, "medium"),
+        (Avatar.Size.large, "large"),
+        (Avatar.Size.xLarge, "xLarge"),
+    ]
 }

--- a/Thumbprint/Targets/Playground/Classes/Inspectable/InspectableViews/UserAvatar+InspectableView.swift
+++ b/Thumbprint/Targets/Playground/Classes/Inspectable/InspectableViews/UserAvatar+InspectableView.swift
@@ -24,13 +24,10 @@ extension UserAvatar: InspectableView {
         initialsProperty.title = "Initials"
         initialsProperty.property = \UserAvatar.initials
 
-        let sizes: [(Avatar.Size, String)] = Avatar.Size.allSizes.map {
-            ($0, $0.name)
-        }
         let sizeProperty = DropdownInspectableProperty(
             inspectedView: self,
             property: \UserAvatar.size,
-            values: sizes
+            values: Self.allSizes
         )
 
         return [
@@ -46,4 +43,12 @@ extension UserAvatar: InspectableView {
         avatar.initials = "AA"
         return avatar
     }
+
+    private static let allSizes = [
+        (Avatar.Size.xSmall, "xSmall"),
+        (Avatar.Size.small, "small"),
+        (Avatar.Size.medium, "medium"),
+        (Avatar.Size.large, "large"),
+        (Avatar.Size.xLarge, "xLarge"),
+    ]
 }

--- a/Thumbprint/Targets/Thumbprint/Components/Avatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Avatar.swift
@@ -7,21 +7,11 @@ import UIKit
 
 public final class Avatar: UIView {
     public struct Size: Equatable {
-        public struct BadgeOffset: Equatable {
-            public let top: CGFloat
-            public let right: CGFloat
-
-            public init(top: CGFloat, right: CGFloat) {
-                self.top = top
-                self.right = right
-            }
-        }
-
         public let dimension: CGFloat
         public let textFont: UIFont
         public let badgeSize: CGFloat
         /// Top and right offsets for the badge.
-        public let badgeOffsets: BadgeOffset
+        public let badgeOffsets: CGVector
 
         public static let xSmall = Size(
             dimension: 32.0,
@@ -31,7 +21,7 @@ public final class Avatar: UIView {
                 uiFontTextStyle: .body
             ).uiFont,
             badgeSize: 12,
-            badgeOffsets: BadgeOffset(top: 0.0, right: 2.0)
+            badgeOffsets: CGVector(dx: 2.0, dy: 0.0)
         )
         public static let small = Size(
             dimension: 48.0,
@@ -41,7 +31,7 @@ public final class Avatar: UIView {
                 uiFontTextStyle: .body
             ).uiFont,
             badgeSize: 12,
-            badgeOffsets: BadgeOffset(top: 1.0, right: 2.0)
+            badgeOffsets: CGVector(dx: 2.0, dy: 1.0)
         )
         public static let medium = Size(
             dimension: 72.0,
@@ -51,7 +41,7 @@ public final class Avatar: UIView {
                 uiFontTextStyle: .body
             ).uiFont,
             badgeSize: 14,
-            badgeOffsets: BadgeOffset(top: 2.0, right: -2.0)
+            badgeOffsets: CGVector(dx: -2.0, dy: 2.0)
         )
         public static let large = Size(
             dimension: 100.0,
@@ -61,7 +51,7 @@ public final class Avatar: UIView {
                 uiFontTextStyle: .body
             ).uiFont,
             badgeSize: 18,
-            badgeOffsets: BadgeOffset(top: 4.0, right: -5.0)
+            badgeOffsets: CGVector(dx: -5.0, dy: 4.0)
         )
         public static let xLarge = Size(
             dimension: 140.0,
@@ -71,13 +61,13 @@ public final class Avatar: UIView {
                 uiFontTextStyle: .body
             ).uiFont,
             badgeSize: 24,
-            badgeOffsets: BadgeOffset(top: 0.0, right: -14.0)
+            badgeOffsets: CGVector(dx: -14.0, dy: 0.0)
         )
 
         public init(dimension: CGFloat,
                     textFont: UIFont,
                     badgeSize: CGFloat,
-                    badgeOffsets: BadgeOffset) {
+                    badgeOffsets: CGVector) {
             self.dimension = dimension
             self.textFont = textFont
             self.badgeSize = badgeSize

--- a/Thumbprint/Targets/Thumbprint/Components/Avatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Avatar.swift
@@ -7,10 +7,21 @@ import UIKit
 
 public final class Avatar: UIView {
     public struct Size: Equatable {
+        public struct BadgeOffset: Equatable {
+            public let top: CGFloat
+            public let right: CGFloat
+
+            public init(top: CGFloat, right: CGFloat) {
+                self.top = top
+                self.right = right
+            }
+        }
+
         public let dimension: CGFloat
-        let textFont: UIFont
-        public let name: String
-        let badgeSize: CGFloat
+        public let textFont: UIFont
+        public let badgeSize: CGFloat
+        /// Top and right offsets for the badge.
+        public let badgeOffsets: BadgeOffset
 
         public static let xSmall = Size(
             dimension: 32.0,
@@ -19,8 +30,8 @@ public final class Avatar: UIView {
                 size: 10,
                 uiFontTextStyle: .body
             ).uiFont,
-            name: "xSmall",
-            badgeSize: 12
+            badgeSize: 12,
+            badgeOffsets: BadgeOffset(top: 0.0, right: 2.0)
         )
         public static let small = Size(
             dimension: 48.0,
@@ -29,8 +40,8 @@ public final class Avatar: UIView {
                 size: 16,
                 uiFontTextStyle: .body
             ).uiFont,
-            name: "small",
-            badgeSize: 12
+            badgeSize: 12,
+            badgeOffsets: BadgeOffset(top: 1.0, right: 2.0)
         )
         public static let medium = Size(
             dimension: 72.0,
@@ -39,8 +50,8 @@ public final class Avatar: UIView {
                 size: 20,
                 uiFontTextStyle: .body
             ).uiFont,
-            name: "medium",
-            badgeSize: 14
+            badgeSize: 14,
+            badgeOffsets: BadgeOffset(top: 2.0, right: -2.0)
         )
         public static let large = Size(
             dimension: 100.0,
@@ -49,8 +60,8 @@ public final class Avatar: UIView {
                 size: 24,
                 uiFontTextStyle: .body
             ).uiFont,
-            name: "large",
-            badgeSize: 18
+            badgeSize: 18,
+            badgeOffsets: BadgeOffset(top: 4.0, right: -5.0)
         )
         public static let xLarge = Size(
             dimension: 140.0,
@@ -59,17 +70,19 @@ public final class Avatar: UIView {
                 size: 32,
                 uiFontTextStyle: .body
             ).uiFont,
-            name: "xLarge",
-            badgeSize: 24
+            badgeSize: 24,
+            badgeOffsets: BadgeOffset(top: 0.0, right: -14.0)
         )
 
-        public static let allSizes = [
-            Size.xSmall,
-            Size.small,
-            Size.medium,
-            Size.large,
-            Size.xLarge,
-        ]
+        public init(dimension: CGFloat,
+                    textFont: UIFont,
+                    badgeSize: CGFloat,
+                    badgeOffsets: BadgeOffset) {
+            self.dimension = dimension
+            self.textFont = textFont
+            self.badgeSize = badgeSize
+            self.badgeOffsets = badgeOffsets
+        }
     }
 
     // Internal

--- a/Thumbprint/Targets/Thumbprint/Components/Avatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Avatar.swift
@@ -10,7 +10,7 @@ public final class Avatar: UIView {
         public let dimension: CGFloat
         public let textFont: UIFont
         public let badgeSize: CGFloat
-        /// Top and right offsets for the badge.
+        /// Top and trailing offsets for the badge (dx: trailing offset, dy: top offset)
         public let badgeOffsets: CGVector
 
         public static let xSmall = Size(

--- a/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
@@ -107,15 +107,6 @@ public final class UserAvatar: UIView {
     private let badgeView: OnlineBadgeView
     private var avatarHeightConstraint: Constraint?
 
-    // Hardcoded top and right offsets for the online now badge.
-    let badgeEdges = [
-        "xSmall": (0.0, 2.0),
-        "small": (1.0, 2.0),
-        "medium": (2.0, -2.0),
-        "large": (4.0, -5.0),
-        "xLarge": (0.0, -14.0),
-    ]
-
     private func setupViews() {
         avatar.label.text = initials
         avatar.clipsToBounds = true
@@ -136,9 +127,8 @@ public final class UserAvatar: UIView {
 
         avatarHeightConstraint?.update(offset: size.dimension)
         badgeView.snp.remakeConstraints { make in
-            let (top, right) = badgeEdges[size.name] ?? (0.0, 0.0)
-            make.top.equalToSuperview().offset(top)
-            make.right.equalToSuperview().offset(right)
+            make.top.equalToSuperview().offset(size.badgeOffsets.top)
+            make.right.equalToSuperview().offset(size.badgeOffsets.right)
             make.height.equalTo(size.badgeSize)
             make.width.equalTo(badgeView.snp.height)
         }

--- a/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
@@ -127,8 +127,8 @@ public final class UserAvatar: UIView {
 
         avatarHeightConstraint?.update(offset: size.dimension)
         badgeView.snp.remakeConstraints { make in
-            make.top.equalToSuperview().offset(size.badgeOffsets.top)
-            make.right.equalToSuperview().offset(size.badgeOffsets.right)
+            make.top.equalToSuperview().offset(size.badgeOffsets.dy)
+            make.right.equalToSuperview().offset(size.badgeOffsets.dx)
             make.height.equalTo(size.badgeSize)
             make.width.equalTo(badgeView.snp.height)
         }

--- a/Thumbprint/Targets/ThumbprintTests/Snapshot/Components/AvatarTest.swift
+++ b/Thumbprint/Targets/ThumbprintTests/Snapshot/Components/AvatarTest.swift
@@ -12,6 +12,14 @@ extension UserAvatar: AvatarView {}
 extension EntityAvatar: AvatarView {}
 
 class AvatarTest: SnapshotTestCase {
+    private static let allSizes: [Avatar.Size] = [
+        .xSmall,
+        .small,
+        .medium,
+        .large,
+        .xLarge,
+    ]
+
     func testInitialsUser() {
         let initials = [
             "AYYYY",
@@ -35,7 +43,7 @@ class AvatarTest: SnapshotTestCase {
         let image = UIImage(named: "eric",
                             in: Bundle.testing,
                             compatibleWith: nil)
-        let views: [UserAvatar] = Avatar.Size.allSizes.map {
+        let views: [UserAvatar] = Self.allSizes.map {
             let avatar = UserAvatar(size: $0)
             avatar.image = image
             return avatar
@@ -67,7 +75,7 @@ class AvatarTest: SnapshotTestCase {
         let image = UIImage(named: "eric",
                             in: Bundle.testing,
                             compatibleWith: nil)
-        let views: [EntityAvatar] = Avatar.Size.allSizes.map {
+        let views: [EntityAvatar] = Self.allSizes.map {
             let avatar = EntityAvatar(size: $0)
             avatar.image = image
             return avatar
@@ -80,7 +88,7 @@ class AvatarTest: SnapshotTestCase {
         let image = UIImage(named: "eric",
                             in: Bundle.testing,
                             compatibleWith: nil)
-        let views: [EntityAvatar] = Avatar.Size.allSizes.map {
+        let views: [EntityAvatar] = Self.allSizes.map {
             let avatar = EntityAvatar(size: $0)
             avatar.image = image
             avatar.isOnline = true
@@ -94,7 +102,7 @@ class AvatarTest: SnapshotTestCase {
         let image = UIImage(named: "eric",
                             in: Bundle.testing,
                             compatibleWith: nil)
-        let views: [UserAvatar] = Avatar.Size.allSizes.map {
+        let views: [UserAvatar] = Self.allSizes.map {
             let avatar = UserAvatar(size: $0)
             avatar.image = image
             avatar.isOnline = true


### PR DESCRIPTION
Update the `Avatar.Size` API to include a public constructor, enabling
one-off sizes to be constructed as needed.