### PR TITLE
Work around SwiftFormat deployment target issue

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -53,6 +53,6 @@ SPEC CHECKSUMS:
   ThumbprintTokens: cfb6b1a3bff5079010ea9b875f558d0016579209
   TTCalendarPicker: 41a4cecbc0be87bcc2aff2740c6cb835a1c26a90
 
-PODFILE CHECKSUM: aff9cedb2eae0cd91dcab451fba55eb64ee2ba43
+PODFILE CHECKSUM: c177bb8c2a8fdda9af01175bb5d1571f3c3caf31
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
PRs are failing due to a build warning about the SwiftFormat pod's
deployment target being set to iOS 7.0, which is too low. Given that we
don't actually care about supporting iOS versions that far back, add a
workaround to the Podfile to set all pods' deployment targets equal to
whatever deployment target we have set for Thumbprint as a whole.