### PR TITLE
Revert "Made avatar background color property public"

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/EntityAvatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/EntityAvatar.swift
@@ -65,13 +65,6 @@ public final class EntityAvatar: UIView {
     }
 
     /**
-     Background color used when initials are displayed
-     */
-    public var avatarBackgroundColor: UIColor? {
-        return avatar.backgroundColor
-    }
-
-    /**
      Initializes an EntityAvatar used for displaying businesses, or service profiles.
 
      - parameters:

--- a/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
@@ -65,13 +65,6 @@ public final class UserAvatar: UIView {
     }
 
     /**
-     Background color used when initials are displayed
-     */
-    public var avatarBackgroundColor: UIColor? {
-        return avatar.backgroundColor
-    }
-
-    /**
      Initializes a UserAvatar used for displaying user accounts, or customers.
 
      - parameters:


### PR DESCRIPTION
Reverting thumbtack/thumbprint-ios#61

The background color property is meant to be something managed purely by the Avatar initial logic as a fallback to not having an image.