### PR TITLE
TextArea: Added sendAction call to notify of text changes in real time

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/TextArea.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/TextArea.swift
@@ -248,5 +248,6 @@ extension TextArea: UITextViewDelegate {
     public func textViewDidChange(_ textView: UITextView) {
         placeholderTextView.isHidden = !textView.text.isEmpty
         updateState()
+        sendActions(for: .editingChanged)
     }
 }


### PR DESCRIPTION
TextArea has nothing in it to notify for text change events in realtime. We have to rely on `NSTextStorageDelegate` to figure out real time text changes. Added a `sendAction` call for `.editingChanged`.