### PR TITLE
Set default content compression/hugging priorities for avatars

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/EntityAvatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/EntityAvatar.swift
@@ -86,6 +86,11 @@ public final class EntityAvatar: UIView {
         self.initials = initials
         self.name = name
 
+        setContentHuggingPriority(.init(rawValue: 800), for: .vertical)
+        setContentHuggingPriority(.init(rawValue: 800), for: .horizontal)
+        setContentCompressionResistancePriority(.init(rawValue: 800), for: .vertical)
+        setContentCompressionResistancePriority(.init(rawValue: 800), for: .horizontal)
+
         setupViews()
         updateSize()
         updateEmptyTheme()

--- a/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/UserAvatar.swift
@@ -88,6 +88,11 @@ public final class UserAvatar: UIView {
 
         accessibilityLabel = self.name
 
+        setContentHuggingPriority(.init(rawValue: 800), for: .vertical)
+        setContentHuggingPriority(.init(rawValue: 800), for: .horizontal)
+        setContentCompressionResistancePriority(.init(rawValue: 800), for: .vertical)
+        setContentCompressionResistancePriority(.init(rawValue: 800), for: .horizontal)
+
         setupViews()
         updateSize()
         updateEmptyTheme()


### PR DESCRIPTION
Previously, avatars had required sizes because they were being explicitly constrained.  Since removing those constraints, we are now relying on the avatars `preferredContentSize`, which negotiates conflicts by using the view's contentHuggingPriority and contentCompressionResistancePriority.  UIView's have a default contentHuggingPriority of 250 and a default compressionResistancePriority of 750.  Setting these both to 800 in both directions ensures that the value will always be higher than any view's default priority.