### PR TITLE
Making Pill class var public

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
@@ -203,15 +203,15 @@ extension Chip: UIContentSizeCategoryAdjusting {
 open class ChipPill: Pill {
     // MARK: - Class configuration
 
-    open override class var defaultHeight: CGFloat {
+    public override class var defaultHeight: CGFloat {
         return 32.0
     }
 
-    override class var defaultPadding: CGFloat {
+    public override class var defaultPadding: CGFloat {
         return 16.0
     }
 
-    open override class var textStyle: Font.TextStyle {
+    public override class var textStyle: Font.TextStyle {
         return .title8
     }
 

--- a/Thumbprint/Targets/Thumbprint/Components/Pill.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Pill.swift
@@ -11,15 +11,15 @@ import UIKit
 open class Pill: UIView, UIContentSizeCategoryAdjusting {
     // MARK: - Class configuration
 
-    class var defaultHeight: CGFloat {
+    public class var defaultHeight: CGFloat {
         return 24.0
     }
 
-    class var defaultPadding: CGFloat {
+    public class var defaultPadding: CGFloat {
         return 12.0
     }
 
-    class var textStyle: Font.TextStyle {
+    public class var textStyle: Font.TextStyle {
         return .title7
     }
 


### PR DESCRIPTION
We have code in our iOS app that need to set default height as Pill to label. Currently it is set differently and in an attempt to modify pill default height it may disturb UI for that particular view ([here](https://github.com/thumbtack/ios/pull/11695#discussion_r935877353)). Exposing these class vars to allow thumbtack iOS codebase to utilize these values as well it will allow subclass to override these for specific cases.