### PR TITLE
Making pill class var open

### DIFF
--- a/Thumbprint/Targets/Playground/Classes/PlaygroundViewController.swift
+++ b/Thumbprint/Targets/Playground/Classes/PlaygroundViewController.swift
@@ -473,6 +473,7 @@ extension PlaygroundViewController: ComponentsListViewControllerDelegate {
         }
 
         let inspectableViewToAdd = componentType.makeInspectable()
+        inspectableViewToAdd.isUserInteractionEnabled = true
         inspectableViews.append(inspectableViewToAdd)
 
         if let footer = inspectableViewToAdd as? Footer {

--- a/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
@@ -203,15 +203,15 @@ extension Chip: UIContentSizeCategoryAdjusting {
 open class ChipPill: Pill {
     // MARK: - Class configuration
 
-    public override class var defaultHeight: CGFloat {
+    open override class var defaultHeight: CGFloat {
         return 32.0
     }
 
-    public override class var defaultPadding: CGFloat {
+    open override class var defaultPadding: CGFloat {
         return 16.0
     }
 
-    public override class var textStyle: Font.TextStyle {
+    open override class var textStyle: Font.TextStyle {
         return .title8
     }
 

--- a/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
@@ -202,6 +202,8 @@ extension Chip: UIContentSizeCategoryAdjusting {
  */
 open class ChipPill: Pill {
     // MARK: - Class configuration
+    private static let defaultHeight: CGFloat = 32.0
+    private static let defaultPadding: CGFloat = 16.0
     private static let baseBorderWidth: CGFloat = 1.0
 
     // MARK: - Border management.
@@ -235,10 +237,10 @@ open class ChipPill: Pill {
             setNeedsLayout()
         }
     }
-    
+
     public override init(adjustsFontForContentSizeCategory: Bool = true) {
         super.init(adjustsFontForContentSizeCategory: adjustsFontForContentSizeCategory)
-        config = Config(height: 32.0, padding: 16.0, textStyle: .title8)
+        config = Config(height: Self.defaultHeight, padding: Self.defaultPadding, textStyle: .title8)
     }
 
     open override func layoutSubviews() {

--- a/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Chips/Chip.swift
@@ -202,19 +202,6 @@ extension Chip: UIContentSizeCategoryAdjusting {
  */
 open class ChipPill: Pill {
     // MARK: - Class configuration
-
-    open override class var defaultHeight: CGFloat {
-        return 32.0
-    }
-
-    open override class var defaultPadding: CGFloat {
-        return 16.0
-    }
-
-    open override class var textStyle: Font.TextStyle {
-        return .title8
-    }
-
     private static let baseBorderWidth: CGFloat = 1.0
 
     // MARK: - Border management.
@@ -247,6 +234,11 @@ open class ChipPill: Pill {
 
             setNeedsLayout()
         }
+    }
+    
+    public override init(adjustsFontForContentSizeCategory: Bool = true) {
+        super.init(adjustsFontForContentSizeCategory: adjustsFontForContentSizeCategory)
+        config = Config(height: 32.0, padding: 16.0, textStyle: .title8)
     }
 
     open override func layoutSubviews() {

--- a/Thumbprint/Targets/Thumbprint/Components/Pill.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Pill.swift
@@ -10,17 +10,23 @@ import UIKit
  */
 open class Pill: UIView, UIContentSizeCategoryAdjusting {
     // MARK: - Class configuration
-
-    open class var defaultHeight: CGFloat {
-        return 24.0
-    }
-
-    open class var defaultPadding: CGFloat {
-        return 12.0
-    }
-
-    open class var textStyle: Font.TextStyle {
-        return .title7
+    
+    public struct Config {
+        public static var defaultHeight: CGFloat = 24.0
+        public static var defaultPadding: CGFloat = 12.0
+        public static var defaultTextStyle: Font.TextStyle = .title7
+        
+        var height: CGFloat
+        var padding: CGFloat
+        var textStyle: Font.TextStyle
+        
+        public init(height: CGFloat = defaultHeight,
+                    padding: CGFloat = defaultPadding,
+                    textStyle: Font.TextStyle = defaultTextStyle) {
+            self.height = height
+            self.padding = padding
+            self.textStyle = textStyle
+        }
     }
 
     // MARK: - Implementation Views
@@ -53,17 +59,17 @@ open class Pill: UIView, UIContentSizeCategoryAdjusting {
 
     var contentHeight: CGFloat {
         if adjustsFontForContentSizeCategory {
-            return Font.scaledValue(Self.defaultHeight, for: label.textStyle)
+            return Font.scaledValue(config.height, for: label.textStyle)
         } else {
-            return Self.defaultHeight
+            return config.height
         }
     }
 
     var sidePadding: CGFloat {
         if adjustsFontForContentSizeCategory {
-            return Font.scaledValue(Self.defaultPadding, for: label.textStyle)
+            return Font.scaledValue(config.padding, for: label.textStyle)
         } else {
-            return Self.defaultPadding
+            return config.padding
         }
     }
 
@@ -195,6 +201,13 @@ open class Pill: UIView, UIContentSizeCategoryAdjusting {
             setNeedsLayout()
         }
     }
+    
+    public var config: Config = Config()  {
+        didSet {
+            label.textStyle = config.textStyle
+            setNeedsLayout()
+        }
+    }
 
     public override var forFirstBaselineLayout: UIView {
         label
@@ -206,7 +219,7 @@ open class Pill: UIView, UIContentSizeCategoryAdjusting {
 
     public init(adjustsFontForContentSizeCategory: Bool = true) {
         self.adjustsFontForContentSizeCategory = adjustsFontForContentSizeCategory
-        self.label = Label(textStyle: Self.textStyle, adjustsFontForContentSizeCategory: adjustsFontForContentSizeCategory)
+        self.label = Label(textStyle: config.textStyle, adjustsFontForContentSizeCategory: adjustsFontForContentSizeCategory)
 
         super.init(frame: .null)
 

--- a/Thumbprint/Targets/Thumbprint/Components/Pill.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Pill.swift
@@ -10,16 +10,16 @@ import UIKit
  */
 open class Pill: UIView, UIContentSizeCategoryAdjusting {
     // MARK: - Class configuration
-    
+
     public struct Config {
         public static var defaultHeight: CGFloat = 24.0
         public static var defaultPadding: CGFloat = 12.0
         public static var defaultTextStyle: Font.TextStyle = .title7
-        
+
         var height: CGFloat
         var padding: CGFloat
         var textStyle: Font.TextStyle
-        
+
         public init(height: CGFloat = defaultHeight,
                     padding: CGFloat = defaultPadding,
                     textStyle: Font.TextStyle = defaultTextStyle) {
@@ -201,8 +201,8 @@ open class Pill: UIView, UIContentSizeCategoryAdjusting {
             setNeedsLayout()
         }
     }
-    
-    public var config: Config = Config()  {
+
+    public var config = Config() {
         didSet {
             label.textStyle = config.textStyle
             setNeedsLayout()

--- a/Thumbprint/Targets/Thumbprint/Components/Pill.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/Pill.swift
@@ -11,15 +11,15 @@ import UIKit
 open class Pill: UIView, UIContentSizeCategoryAdjusting {
     // MARK: - Class configuration
 
-    public class var defaultHeight: CGFloat {
+    open class var defaultHeight: CGFloat {
         return 24.0
     }
 
-    public class var defaultPadding: CGFloat {
+    open class var defaultPadding: CGFloat {
         return 12.0
     }
 
-    public class var textStyle: Font.TextStyle {
+    open class var textStyle: Font.TextStyle {
         return .title7
     }
 


### PR DESCRIPTION
Made a mistake in my previous [PR](https://github.com/thumbtack/thumbprint-ios/pull/100)
Instead of making class var open for overridable made them public. This is a fix for it.