### PR TITLE
Add small navigation sync icon

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Icons.swift
+++ b/Thumbprint/Targets/Thumbprint/Icons.swift
@@ -355,6 +355,7 @@ public enum Icon: String, CaseIterable {
     case navigationSettingsSmall = "navigation_settings--small"
     case navigationShrinkMedium = "navigation_shrink--medium"
     case navigationShrinkSmall = "navigation_shrink--small"
+    case navigationSyncSmall = "navigation_sync--small"
     case navigationSyncTiny = "navigation_sync--tiny"
     case notificationAlertsBlockedMedium = "notificationAlerts_blocked--medium"
     case notificationAlertsBlockedSmall = "notificationAlerts_blocked--small"


### PR DESCRIPTION
Needed to add small navigation sync icon for Engagement landing page [error retry view](https://www.figma.com/file/dVM3MYRzREKzgn1oqwILW2/Native-Landing-Page?node-id=652%3A48451&t=aw99BPbO8qRMMK8A-4).