### PR TITLE
Update ShadowCard to support updating shadowImage

### DIFF
--- a/Thumbprint/Targets/Thumbprint/Components/ShadowCard.swift
+++ b/Thumbprint/Targets/Thumbprint/Components/ShadowCard.swift
@@ -16,7 +16,14 @@ public final class ShadowCard: UIView {
         }
     }
 
+    public var shadowImage: UIImage {
+        didSet {
+            shadowImageView.image = shadowImage
+        }
+    }
+
     public init(shadowImage: UIImage = Shadow.roundedShadow300) {
+        self.shadowImage = shadowImage
         self.shadowImageView = UIImageView(image: shadowImage)
         self.mainView = UIView()
         self.isHighlighted = false


### PR DESCRIPTION
Added functionality to `ShadowCard` to allow setting/updating `shadowImage` after view initialization. This is required for a server driven UI feature where we need to update the shadow based on BE response.

I manually verified this works by pointing ios repo to local thumbprint-ios.