### PR TITLE
Specify exact version for dependencies + using swiftlint plugin to autofix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,39 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "collectionconcurrencykit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
-      "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
-      }
-    },
-    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",
       "state" : {
         "revision" : "f222cbdf325885926566172f6f5f06af95473158",
         "version" : "5.6.0"
-      }
-    },
-    {
-      "identity" : "sourcekitten",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
-      "state" : {
-        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
-        "version" : "0.34.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
       }
     },
     {
@@ -46,48 +19,21 @@
       }
     },
     {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "013a48e2312e57b7b355db25bd3ea75282ebf274",
-        "version" : "0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-06-a"
-      }
-    },
-    {
       "identity" : "swiftformat",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "fee7e1a1ac9518cfe3c4673382368641ccbdc62c",
-        "version" : "0.51.7"
+        "revision" : "d98aa3f098f38e93324cfda8ee909581cf3d791d",
+        "version" : "0.51.8"
       }
     },
     {
-      "identity" : "swiftlint",
+      "identity" : "swiftlintplugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/SwiftLint.git",
+      "location" : "https://github.com/lukepistrol/SwiftLintPlugin",
       "state" : {
-        "revision" : "eb85125a5f293de3d3248af259980c98bc2b1faa",
-        "version" : "0.51.0"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
-        "version" : "7.0.1"
+        "revision" : "d3ec7fb242ebe1d8e23bf17e58a1e27d43125994",
+        "version" : "0.2.6"
       }
     },
     {
@@ -106,15 +52,6 @@
       "state" : {
         "revision" : "753d5327ae08e50d94cb79e037cf6166f4a61c2f",
         "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "f47ba4838c30dbd59998a4e4c87ab620ff959e8a",
-        "version" : "5.0.5"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "d98aa3f098f38e93324cfda8ee909581cf3d791d",
-        "version" : "0.51.8"
+        "revision" : "7ff506897aa5bdaf94f077087a2025b9505da112",
+        "version" : "0.51.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,12 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/SnapKit/SnapKit.git", exact: "5.6.0"),
-        .package(url: "https://github.com/thumbtack/TTCalendarPicker.git", exact: "0.2.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.11.0"),
-        .package(url: "https://github.com/thumbtack/thumbprint-tokens.git", exact: "13.0.1"),
-        .package(url: "https://github.com/lukepistrol/SwiftLintPlugin", exact: "0.2.6"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.51.8"),
+        .package(url: "https://github.com/SnapKit/SnapKit.git", from: "5.6.0"),
+        .package(url: "https://github.com/thumbtack/TTCalendarPicker.git", from: "0.2.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.0"),
+        .package(url: "https://github.com/thumbtack/thumbprint-tokens.git", from: "13.0.1"),
+        .package(url: "https://github.com/lukepistrol/SwiftLintPlugin", from: "0.2.6"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.51.9"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,12 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/SnapKit/SnapKit.git", .upToNextMajor(from: "5.6.0")),
-        .package(url: "https://github.com/thumbtack/TTCalendarPicker.git", from: "0.2.0"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.0"),
-        .package(url: "https://github.com/thumbtack/thumbprint-tokens.git", from: "13.0.1"),
-        .package(url: "https://github.com/realm/SwiftLint.git", from: "0.51.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4"),
+        .package(url: "https://github.com/SnapKit/SnapKit.git", exact: "5.6.0"),
+        .package(url: "https://github.com/thumbtack/TTCalendarPicker.git", exact: "0.2.0"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.11.0"),
+        .package(url: "https://github.com/thumbtack/thumbprint-tokens.git", exact: "13.0.1"),
+        .package(url: "https://github.com/lukepistrol/SwiftLintPlugin", exact: "0.2.6"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.51.8"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -38,7 +38,7 @@ let package = Package(
                 .copy("Resources/Assets.xcassets"),
             ],
             plugins: [
-                .plugin(name: "SwiftLintPlugin", package: "SwiftLint"),
+                .plugin(name: "SwiftLint", package: "SwiftLintPlugin"),
                 .plugin(name: "SwiftFormat", package: "SwiftFormat"),
             ]
         ),


### PR DESCRIPTION
- Pinning exact version of dependencies
- Using swiftlint auto fix plugin:

<img width="271" alt="Screenshot 2023-05-19 at 10 55 45 AM" src="https://github.com/thumbtack/thumbprint-ios/assets/113396903/1b04a39b-05d3-40f9-941a-69044c7adfd7">
