### PR TITLE
Add tiny notification icon mapping

### DIFF
--- a/Sources/Thumbprint/Icons.swift
+++ b/Sources/Thumbprint/Icons.swift
@@ -378,6 +378,7 @@ public enum Icon: String, CaseIterable {
     case notificationAlertsInfoFilledSmall = "notificationAlerts_info-filled--small"
     case notificationAlertsNotificationMedium = "notificationAlerts_notification--medium"
     case notificationAlertsNotificationSmall = "notificationAlerts_notification--small"
+    case notificationAlertsNotificationTiny = "notificationAlerts_notification--tiny"
     case notificationAlertsNotificationFilledMedium = "notificationAlerts_notification-filled--medium"
     case notificationAlertsWarningMedium = "notificationAlerts_warning--medium"
     case notificationAlertsWarningSmall = "notificationAlerts_warning--small"


### PR DESCRIPTION
Icon asset already exists in `ios` repo