### PR TITLE
Add small waves icon mapping

### DIFF
--- a/Sources/Thumbprint/Icons.swift
+++ b/Sources/Thumbprint/Icons.swift
@@ -194,6 +194,7 @@ public enum Icon: String, CaseIterable {
     case contentModifierWaterDropsMedium = "contentModifier_water-drops--medium"
     case contentModifierWaterDropsSmall = "contentModifier_water-drops--small"
     case contentModifierWavesMedium = "contentModifier_waves--medium"
+    case contentModifierWavesSmall = "contentModifier_waves--small"
     case contentModifierWavesTiny = "contentModifier_waves--tiny"
     case contentModifierWebsiteMedium = "contentModifier_website--medium"
     case contentModifierWebsiteSmall = "contentModifier_website--small"


### PR DESCRIPTION
Mapping the small wave icon. It is needed for one of the cards on the Home Tab on iOS
![image](https://github.com/thumbtack/thumbprint-ios/assets/82894100/8e9323ba-a108-4a6b-8edd-2b152aa77efe)
