### PR TITLE
Fix index out of bounds issue with dropdown

### DIFF
--- a/Sources/Thumbprint/Components/Dropdown.swift
+++ b/Sources/Thumbprint/Components/Dropdown.swift
@@ -53,7 +53,7 @@ public final class Dropdown: Control, UIContentSizeCategoryAdjusting {
     public var selectedIndex: Int? {
         didSet {
             if oldValue != selectedIndex { sendActions(for: .valueChanged) }
-            guard let selectedIndex = selectedIndex else {
+            guard let selectedIndex else {
                 label.text = placeholder
                 return
             }
@@ -188,7 +188,7 @@ public final class Dropdown: Control, UIContentSizeCategoryAdjusting {
 
     @objc
     private func pickerViewDidShow(notification: Notification) {
-        if isFirstResponder, selectedIndex == nil {
+        if isFirstResponder, selectedIndex == nil, pickerView.selectedRow(inComponent: 0) >= 0 {
             selectedIndex = pickerView.selectedRow(inComponent: 0)
         }
     }

--- a/Sources/Thumbprint/Components/Dropdown.swift
+++ b/Sources/Thumbprint/Components/Dropdown.swift
@@ -191,7 +191,7 @@ public final class Dropdown: Control, UIContentSizeCategoryAdjusting {
         if isFirstResponder, selectedIndex == nil {
             let numberOfRowsInPicker = pickerView.numberOfRows(inComponent: 0)
             let selectedRow = pickerView.selectedRow(inComponent: 0)
-            if (0..<numberOfRowsInPicker).contains(selectedRow) {
+            if (0 ..< numberOfRowsInPicker).contains(selectedRow) {
                 selectedIndex = selectedRow
             }
         }

--- a/Sources/Thumbprint/Components/Dropdown.swift
+++ b/Sources/Thumbprint/Components/Dropdown.swift
@@ -191,7 +191,7 @@ public final class Dropdown: Control, UIContentSizeCategoryAdjusting {
         if isFirstResponder, selectedIndex == nil {
             let numberOfRowsInPicker = pickerView.numberOfRows(inComponent: 0)
             let selectedRow = pickerView.selectedRow(inComponent: 0)
-            if selectedRow < numberOfRowsInPicker, selectedRow >= 0 {
+            if (0..<numberOfRowsInPicker).contains(selectedRow) {
                 selectedIndex = selectedRow
             }
         }

--- a/Sources/Thumbprint/Components/Dropdown.swift
+++ b/Sources/Thumbprint/Components/Dropdown.swift
@@ -188,8 +188,12 @@ public final class Dropdown: Control, UIContentSizeCategoryAdjusting {
 
     @objc
     private func pickerViewDidShow(notification: Notification) {
-        if isFirstResponder, selectedIndex == nil, pickerView.selectedRow(inComponent: 0) >= 0 {
-            selectedIndex = pickerView.selectedRow(inComponent: 0)
+        if isFirstResponder, selectedIndex == nil {
+            let numberOfRowsInPicker = pickerView.numberOfRows(inComponent: 0)
+            let selectedRow = pickerView.selectedRow(inComponent: 0)
+            if selectedRow < numberOfRowsInPicker, selectedRow >= 0 {
+                selectedIndex = selectedRow
+            }
         }
     }
 

--- a/Thumbprint/Thumbprint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Thumbprint/Thumbprint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "32f641cf24fc7abc1c591a2025e9f2f572648b0f",
+        "version" : "1.7.2"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",
@@ -50,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "013a48e2312e57b7b355db25bd3ea75282ebf274",
-        "version" : "0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-06-a"
+        "revision" : "27cd6190ce0628847a3f8050794d6e627ad79c08",
+        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-05-02-a"
       }
     },
     {
@@ -59,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "fee7e1a1ac9518cfe3c4673382368641ccbdc62c",
-        "version" : "0.51.7"
+        "revision" : "f9dc4ddc78ef09d58abb0f5aa8fb855282f4dfaa",
+        "version" : "0.51.10"
       }
     },
     {
@@ -68,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint.git",
       "state" : {
-        "revision" : "eb85125a5f293de3d3248af259980c98bc2b1faa",
-        "version" : "0.51.0"
+        "revision" : "34f5ffa7f706ed2dfe11bd300e5197e8878e3856",
+        "version" : "0.52.2"
       }
     },
     {


### PR DESCRIPTION
Adding a minor patch for a bug where the `selectedIndex` of `Dropdown` can potentially be set to `-1` by the `pickerView.selectedRow` API.

This change inspects the selected row and only updates the selected if the index is non-negative.