### PR TITLE
Partial sheet panning fix

### DIFF
--- a/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -235,6 +235,13 @@ open class PartialSheetPresentationController: UIPresentationController {
             partialSheetDelegate?.partialSheetPresentationControllerDidDismissSheet?(self)
 
             NotificationCenter.default.post(name: PartialSheetPresentationController.partialSheetDidDismissNotification, object: nil)
+        } else {
+            // This is a wildly hacky solution to the problem discussed here: https://thumbtack.slack.com/archives/C04L74B6M/p1697811811558819
+            // "If you drag the sheet at all and then let go, the CTAs [and any other gestures] become unresponsive"
+            // Solution provided here: https://stackoverflow.com/a/74320743
+            // TODO: (mdinicola) Check to see if this is solved in future iOS versions
+            presentedViewController.view.bounds.origin.y = .leastNonzeroMagnitude
+            presentedViewController.view.bounds.origin.y = .zero
         }
     }
 


### PR DESCRIPTION
We had disabled panning in partial sheets due to a bug that I've now narrowed down to Apple's implementation. In my testing the described issue no longer occurs. The clients will still have to re-enable panning after this is merged.