### PR TITLE
Make Pill, button and PartialSheetPresentation sendable + Update package resolved

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e57fd28f7238cd1744aae40f6e2a77e9c80533f9725afe4dfaf660a7c1b90530",
+  "originHash" : "3ed2b658c944f9da0c076d8a42ff6448bf7e5a8c3b64a3006c2d62395275b3d9",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/thumbtack/thumbprint-tokens.git",
       "state" : {
-        "revision" : "746c43b8e75d4678d8bf3fcf2582b74097b0237b",
-        "version" : "13.0.2"
+        "revision" : "b19b9b12db0e35a19adf38d9a769c1cb0b5eb2fb",
+        "version" : "13.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/SnapKit/SnapKit.git", exact: "5.6.0"),
         .package(url: "https://github.com/thumbtack/TTCalendarPicker.git", exact: "0.2.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", exact: "1.16.0"),
-        .package(url: "https://github.com/thumbtack/thumbprint-tokens.git", exact: "13.0.2"),
+        .package(url: "https://github.com/thumbtack/thumbprint-tokens.git", exact: "13.0.3"),
         .package(url: "https://github.com/realm/SwiftLint.git", exact: "0.54.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.52.11"),
     ],

--- a/Sources/Thumbprint/Components/Button.Theme.swift
+++ b/Sources/Thumbprint/Components/Button.Theme.swift
@@ -154,7 +154,7 @@ public extension Button {
     /**
      * Button size/layout configuration
      */
-    struct Size: Equatable {
+    struct Size: Equatable, Sendable {
         /// Text style for the button label.
         public let textStyle: Font.TextStyle
 

--- a/Sources/Thumbprint/Components/Pill.swift
+++ b/Sources/Thumbprint/Components/Pill.swift
@@ -73,7 +73,7 @@ open class Pill: UIView, UIContentSizeCategoryAdjusting {
         }
     }
 
-    public struct Theme: Equatable {
+    public struct Theme: Equatable, Sendable {
         public let backgroundColor: UIColor
         public let contentColor: UIColor
         public let name: String? //  Used by some old legacy logic that stores it.

--- a/Sources/Thumbprint/Font.swift
+++ b/Sources/Thumbprint/Font.swift
@@ -122,7 +122,7 @@ public extension Font {
 
 // MARK: - Public Member Types
 public extension Font {
-    struct TextStyle: Equatable, Hashable {
+    struct TextStyle: Equatable, Hashable, Sendable {
         /// Static font for this text style.
         public let uiFont: UIFont
         public let weight: ThumbprintTokens.FontWeight

--- a/Sources/Thumbprint/Presentations/Presentation.swift
+++ b/Sources/Thumbprint/Presentations/Presentation.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 public enum Presentation {
     public static let partialSheet: UIViewControllerTransitioningDelegate = PartialSheetPresentation()
 }

--- a/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
+++ b/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDelegate, Sendable {
+open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDelegate {
     private class PercentDrivenInteractiveTransition: UIPercentDrivenInteractiveTransition, UIViewControllerAnimatedTransitioning {
         private var presentedViewFrame: CGRect = .zero
         private let triggerPercentage: CGFloat = 0.42

--- a/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
+++ b/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDelegate {
+open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDelegate, Sendable {
     private class PercentDrivenInteractiveTransition: UIPercentDrivenInteractiveTransition, UIViewControllerAnimatedTransitioning {
         private var presentedViewFrame: CGRect = .zero
         private let triggerPercentage: CGFloat = 0.42

--- a/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
+++ b/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDelegate {
     private class PercentDrivenInteractiveTransition: UIPercentDrivenInteractiveTransition, UIViewControllerAnimatedTransitioning {
         private var presentedViewFrame: CGRect = .zero

--- a/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
+++ b/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
+++ b/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
@@ -623,6 +623,7 @@
 			baseConfigurationReference = 08C813F925FF093F001F9DFE /* TestsHostApp-Debug.xcconfig */;
 			buildSettings = {
 				DEAD_CODE_STRIPPING = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Debug;
 		};
@@ -631,6 +632,7 @@
 			baseConfigurationReference = 08C813F825FF093F001F9DFE /* TestsHostApp-Release.xcconfig */;
 			buildSettings = {
 				DEAD_CODE_STRIPPING = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Release;
 		};
@@ -690,7 +692,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Targets/Playground/Config/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -703,6 +705,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -758,7 +761,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Targets/Playground/Config/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -770,6 +773,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = targeted;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
+++ b/Thumbprint/Thumbprint.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -613,6 +614,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Release;
 		};

--- a/Thumbprint/Thumbprint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Thumbprint/Thumbprint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "55ec2b2e8835e0fe998e5eaab1e49761370ba5ee12434cebea0b3ac4008884df",
+  "originHash" : "aa2b781269de9c404c990f5d3b13b99f27552758e1f78e09fa46f6e60519ae31",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/drmohundro/SWXMLHash.git",
       "state" : {
-        "revision" : "4d0f62f561458cbe1f732171e625f03195151b60",
-        "version" : "7.0.1"
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/thumbtack/thumbprint-tokens.git",
       "state" : {
-        "revision" : "746c43b8e75d4678d8bf3fcf2582b74097b0237b",
-        "version" : "13.0.2"
+        "revision" : "b19b9b12db0e35a19adf38d9a769c1cb0b5eb2fb",
+        "version" : "13.0.3"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
+        "revision" : "9234124cff5e22e178988c18d8b95a8ae8007f76",
+        "version" : "5.1.2"
       }
     }
   ],

--- a/Thumbprint/Thumbprint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Thumbprint/Thumbprint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "55ec2b2e8835e0fe998e5eaab1e49761370ba5ee12434cebea0b3ac4008884df",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "32f641cf24fc7abc1c591a2025e9f2f572648b0f",
-        "version" : "1.7.2"
+        "revision" : "c9c3df6ab812de32bae61fc0cd1bf6d45170ebf0",
+        "version" : "1.8.2"
       }
     },
     {
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "bb0ea08db8e73324fe6c3727f755ca41a23ff2f4",
-        "version" : "1.14.2"
+        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
+        "version" : "1.16.0"
       }
     },
     {
@@ -59,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     },
     {
@@ -68,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "d37a477177d5d4ff2a3ae6328eaaab5bf793e702",
-        "version" : "0.52.9"
+        "revision" : "ad7707bd34a33fa64a2c593c53deaa7d7469e2f0",
+        "version" : "0.52.11"
       }
     },
     {
@@ -77,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/SwiftLint.git",
       "state" : {
-        "revision" : "6d2e58271ebc14c37bf76d7c9f4082cc15bad718",
-        "version" : "0.53.0"
+        "revision" : "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
+        "version" : "0.54.0"
       }
     },
     {
@@ -104,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/thumbtack/thumbprint-tokens.git",
       "state" : {
-        "revision" : "a91f2295af6fe22bba47807ec384c241aa734985",
-        "version" : "13.0.1"
+        "revision" : "746c43b8e75d4678d8bf3fcf2582b74097b0237b",
+        "version" : "13.0.2"
       }
     },
     {
@@ -127,5 +128,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
Did change only these so we could migrate membership to complete

<img width="598" alt="Screenshot 2024-07-08 at 10 18 05 AM" src="https://github.com/thumbtack/thumbprint-ios/assets/113396903/ab3ddce3-6257-414f-8a70-0112ac3a985d">

- set concurrency checking to complete
- Upgrade thumbprint token to 13.0.3
- Fix host app and playground not building

TODO:
- [ ]  Enable strict concurrency for the framework
- [ ] Try to run playground in CI
