### PR TITLE
Add "interactively" parameter to partial sheet presentation delegate

### DIFF
--- a/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
+++ b/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
@@ -7,9 +7,11 @@ open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDele
         private let triggerPercentage: CGFloat = 0.42
 
         let panGestureRecognizer: UIPanGestureRecognizer
+        let completion: ((_ didFinish: Bool) -> Void)?
 
-        required init(panGestureRecognizer: UIPanGestureRecognizer) {
+        required init(panGestureRecognizer: UIPanGestureRecognizer, completion: ((_ didFinish: Bool) -> Void)?) {
             self.panGestureRecognizer = panGestureRecognizer
+            self.completion = completion
 
             super.init()
 
@@ -40,8 +42,10 @@ open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDele
             case .ended:
                 if percentComplete > triggerPercentage {
                     finish()
+                    completion?(true)
                 } else {
                     cancel()
+                    completion?(false)
                 }
 
             default:
@@ -76,7 +80,9 @@ open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDele
             return nil
         }
 
-        return PercentDrivenInteractiveTransition(panGestureRecognizer: partialSheetPresentationController.panGestureRecognizer)
+        return PercentDrivenInteractiveTransition(panGestureRecognizer: partialSheetPresentationController.panGestureRecognizer) { didFinish in
+            partialSheetPresentationController.didCompleteInteractiveTransition(success: didFinish)
+        }
     }
 
     public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {

--- a/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
+++ b/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentation.swift
@@ -7,11 +7,11 @@ open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDele
         private let triggerPercentage: CGFloat = 0.42
 
         let panGestureRecognizer: UIPanGestureRecognizer
-        let completion: ((_ didFinish: Bool) -> Void)?
+        let transitionCompletion: (() -> Void)?
 
-        required init(panGestureRecognizer: UIPanGestureRecognizer, completion: ((_ didFinish: Bool) -> Void)?) {
+        required init(panGestureRecognizer: UIPanGestureRecognizer, transitionCompletion: (() -> Void)?) {
             self.panGestureRecognizer = panGestureRecognizer
-            self.completion = completion
+            self.transitionCompletion = transitionCompletion
 
             super.init()
 
@@ -42,15 +42,18 @@ open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDele
             case .ended:
                 if percentComplete > triggerPercentage {
                     finish()
-                    completion?(true)
                 } else {
                     cancel()
-                    completion?(false)
                 }
 
             default:
                 break
             }
+        }
+
+        override func finish() {
+            super.finish()
+            transitionCompletion?()
         }
 
         public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
@@ -80,8 +83,8 @@ open class PartialSheetPresentation: NSObject, UIViewControllerTransitioningDele
             return nil
         }
 
-        return PercentDrivenInteractiveTransition(panGestureRecognizer: partialSheetPresentationController.panGestureRecognizer) { didFinish in
-            partialSheetPresentationController.didCompleteInteractiveTransition(success: didFinish)
+        return PercentDrivenInteractiveTransition(panGestureRecognizer: partialSheetPresentationController.panGestureRecognizer) {
+            partialSheetPresentationController.didCompleteInteractiveTransition()
         }
     }
 

--- a/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
+++ b/Sources/Thumbprint/Presentations/Sheet/PartialSheetPresentationController.swift
@@ -101,10 +101,8 @@ open class PartialSheetPresentationController: UIPresentationController {
 
     // Indicates that the modal was dismissed either by tapping the background area, or swiping down
     var userDidDismissModal = false
-    func didCompleteInteractiveTransition(success: Bool) {
-        if success {
-            userDidDismissModal = true
-        }
+    func didCompleteInteractiveTransition() {
+        userDidDismissModal = true
     }
 
     public var partialSheetDelegate: PartialSheetPresentationControllerDelegate? {


### PR DESCRIPTION
Adds an additional boolean argument, `interactively`, to the partialSheetPresentationControllerDidDismissSheet() method of PartialSheetPresentationControllerDelegate.  This value is set to true when the dismissal of the modal is triggered by user interaction with the modal container (tapping the darkened background area or swiping down on the modal), rather than with the contents of the model itself.  