### PR TITLE
[COMPLETE] Make Size sendable in Avatar

### DIFF
--- a/Sources/Thumbprint/Components/Avatar.swift
+++ b/Sources/Thumbprint/Components/Avatar.swift
@@ -6,7 +6,7 @@ import UIKit
  */
 
 public final class Avatar: UIView {
-    public struct Size: Equatable {
+    public struct Size: Equatable, Sendable {
         public let dimension: CGFloat
         public let textFont: UIFont
         public let badgeSize: CGFloat


### PR DESCRIPTION
Make size sendable in Avatar to fix this waning:
[static property 'small' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6](https://next-jenkins.thumbtack.io/job/verify-ios-pr/job/PR-18553/3/console) in browse
